### PR TITLE
Prevent multiple Config resource creation with a validating webhook

### DIFF
--- a/config/rbac/rbac_role.yaml
+++ b/config/rbac/rbac_role.yaml
@@ -107,6 +107,26 @@ rules:
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - operator.istio.io
+  resources:
+  - configs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   verbs:

--- a/pkg/webhook/add_server.go
+++ b/pkg/webhook/add_server.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2019 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"github.com/banzaicloud/istio-operator/pkg/webhook/server"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, server.Add)
+}

--- a/pkg/webhook/server/config_validation_webhook.go
+++ b/pkg/webhook/server/config_validation_webhook.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2019 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/builder"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+
+	istiov1beta1 "github.com/banzaicloud/istio-operator/pkg/apis/operator/v1beta1"
+)
+
+func init() {
+	webhooks = append(webhooks, NewConfigValidationWebhook)
+}
+
+const (
+	configValidationWebhookName               = "istio.validation.banzaicloud.io"
+	configValidationWebhookPath               = "/validate-istio-config"
+	configValidationWebhookAlreadyExistsError = "istio config resource already exists"
+)
+
+// NewConfigValidationWebhook initializes an Istio config resource validator webhook configuration
+func NewConfigValidationWebhook(mgr manager.Manager, logger logr.Logger) (*admission.Webhook, error) {
+	return builder.NewWebhookBuilder().
+		Name(configValidationWebhookName).
+		Path(configValidationWebhookPath).
+		FailurePolicy(admissionregistrationv1beta1.Ignore).
+		Validating().
+		NamespaceSelector(&metav1.LabelSelector{}).
+		Operations(admissionregistrationv1beta1.Create).
+		ForType(&istiov1beta1.Config{}).
+		Handlers(&istioConfigValidator{
+			logger: logger,
+		}).
+		WithManager(mgr).
+		Build()
+}
+
+type istioConfigValidator struct {
+	client client.Client
+	logger logr.Logger
+}
+
+// istioConfigValidator implements admission.Handler.
+var _ admission.Handler = &istioConfigValidator{}
+
+// Automatically generate RBAC rules to allow the Controller to validate IstioConfigs
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=operator.istio.io,resources=configs,verbs=get;list;watch
+func (wh *istioConfigValidator) Handle(ctx context.Context, req types.Request) types.Response {
+	var configs istiov1beta1.ConfigList
+
+	err := wh.client.List(context.TODO(), &client.ListOptions{}, &configs)
+	if err != nil {
+		wh.logger.Error(err, "could not list istio config objects")
+	}
+	if len(configs.Items) == 0 {
+		return admission.ValidationResponse(true, "")
+	}
+
+	return admission.ValidationResponse(false, configValidationWebhookAlreadyExistsError)
+}
+
+// istioConfigValidator implements inject.Client.
+var _ inject.Client = &istioConfigValidator{}
+
+// InjectClient injects the client into the istioConfigValidator
+func (wh *istioConfigValidator) InjectClient(c client.Client) error {
+	wh.client = c
+	return nil
+}

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"os"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var webhooks []func(manager.Manager, logr.Logger) (*admission.Webhook, error)
+
+func Add(mgr manager.Manager) error {
+	return add(mgr)
+}
+
+func add(mgr manager.Manager) error {
+	log := logf.ZapLogger(false).WithName("webhook-server")
+
+	name := "istio-operator-webhook"
+	namespace := "istio-system"
+	secretName := "istio-operator-webhook-server-secret"
+
+	svr, err := webhook.NewServer(name, mgr, webhook.ServerOptions{
+		CertDir: "/tmp/cert",
+		BootstrapOptions: &webhook.BootstrapOptions{
+			ValidatingWebhookConfigName: name,
+			Secret: &types.NamespacedName{
+				Namespace: namespace,
+				Name:      secretName,
+			},
+			Service: &webhook.Service{
+				Namespace: namespace,
+				Name:      name,
+				Selectors: map[string]string{
+					"control-plane": "controller-manager",
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Error(err, "could not create new webhook server")
+		os.Exit(2)
+	}
+
+	webhooksToRegister := make([]webhook.Webhook, 0)
+	for _, f := range webhooks {
+		wh, err := f(mgr, log)
+		if err != nil {
+			continue
+		}
+		webhooksToRegister = append(webhooksToRegister, wh)
+	}
+
+	if err := svr.Register(webhooksToRegister...); err != nil {
+		log.Error(err, "could not register webhooks")
+		os.Exit(2)
+	} else {
+		log.Info("started")
+	}
+
+	return nil
+}


### PR DESCRIPTION

| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | fixes #48 
| License         | Apache 2.0

### What's in this PR?

It implements a validating admission webhook to prevent multiple `Config` resource creation.

### Why?

Right now the operator supports only one Istio deployment per cluster.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
