### PR TITLE
Fix federated Istio deployment replica counts

### DIFF
--- a/config/crds/istio_v1beta1_remoteistio.yaml
+++ b/config/crds/istio_v1beta1_remoteistio.yaml
@@ -36,6 +36,13 @@ spec:
               items:
                 type: string
               type: array
+            citadel:
+              description: Citadel configuration options
+              properties:
+                replicaCount:
+                  format: int32
+                  type: integer
+              type: object
             controlPlaneSecurityEnabled:
               description: ControlPlaneSecurityEnabled control plane services are
                 communicating through mTLS
@@ -60,6 +67,13 @@ spec:
               type: string
             includeIPRanges:
               type: string
+            sidecarInjector:
+              description: SidecarInjector configuration options
+              properties:
+                replicaCount:
+                  format: int32
+                  type: integer
+              type: object
           required:
           - enabledServices
           type: object

--- a/config/samples/istio_v1beta1_remoteistio.yaml
+++ b/config/samples/istio_v1beta1_remoteistio.yaml
@@ -5,6 +5,8 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: remoteistio-sample
 spec:
+  autoInjectionNamespaces:
+  - "default"
   includeIPRanges: "*"
   excludeIPRanges: ""
   enabledServices:
@@ -19,3 +21,7 @@ spec:
   - name: "zipkin"
     labelSelector: "app=jaeger"
   controlPlaneSecurityEnabled: true
+  citadel:
+      replicaCount: 1
+  sidecarInjector:
+      replicaCount: 1

--- a/docs/federation/example/README.md
+++ b/docs/federation/example/README.md
@@ -91,14 +91,14 @@ REMOTE_KUBECONFIG_FILE=$(docs/federation/example/generate-kubeconfig.sh)
 
 ```bash
 kubectl config use-context ${CONTEXT_CENTRAL}
-kubectl create secret generic remote-cluster --from-file ${REMOTE_KUBECONFIG_FILE} -n istio-system
+kubectl create secret generic remoteistio-sample --from-file ${REMOTE_KUBECONFIG_FILE} -n istio-system
 rm -f ${REMOTE_KUBECONFIG_FILE}
 ```
 
 ### The added secret must be labeled for Istio
 
 ```bash
-kubectl label secret remote-cluster istio/multiCluster=true -n istio-system
+kubectl label secret remoteistio-sample istio/multiCluster=true -n istio-system
 ```
 
 ### Create the Istio remote config on the central cluster and label the default namespace for auto sidecar injection on the remote cluster as well
@@ -118,7 +118,6 @@ NAME                    READY   STATUS    RESTARTS   AGE
 echo-59d4b7c4cb-v29zb   2/2     Running   0          1m
 
 kubectl config use-context ${CONTEXT_REMOTE}
-kubectl label namespace default istio-injection=enabled
 kubectl apply -f docs/federation/example/echo-service.yml
 
 kubectl get pods

--- a/pkg/apis/istio/v1beta1/remoteistio_types.go
+++ b/pkg/apis/istio/v1beta1/remoteistio_types.go
@@ -51,6 +51,10 @@ type RemoteIstioSpec struct {
 	AutoInjectionNamespaces []string `json:"autoInjectionNamespaces,omitempty"`
 	// ControlPlaneSecurityEnabled control plane services are communicating through mTLS
 	ControlPlaneSecurityEnabled bool `json:"controlPlaneSecurityEnabled,omitempty"`
+	// Citadel configuration options
+	Citadel CitadelConfiguration `json:"citadel,omitempty"`
+	// SidecarInjector configuration options
+	SidecarInjector SidecarInjectorConfiguration `json:"sidecarInjector,omitempty"`
 
 	signCert SignCert
 }
@@ -86,4 +90,18 @@ type RemoteIstioList struct {
 
 func init() {
 	SchemeBuilder.Register(&RemoteIstio{}, &RemoteIstioList{})
+}
+
+func SetRemoteIstioDefaults(remoteconfig *RemoteIstio) {
+	if remoteconfig.Spec.IncludeIPRanges == "" {
+		remoteconfig.Spec.IncludeIPRanges = defaultIncludeIPRanges
+	}
+	// Citadel config
+	if remoteconfig.Spec.Citadel.ReplicaCount == 0 {
+		remoteconfig.Spec.Citadel.ReplicaCount = defaultReplicaCount
+	}
+	// SidecarInjector config
+	if remoteconfig.Spec.SidecarInjector.ReplicaCount == 0 {
+		remoteconfig.Spec.SidecarInjector.ReplicaCount = defaultReplicaCount
+	}
 }

--- a/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
@@ -304,6 +304,8 @@ func (in *RemoteIstioSpec) DeepCopyInto(out *RemoteIstioSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	out.Citadel = in.Citadel
+	out.SidecarInjector = in.SidecarInjector
 	in.signCert.DeepCopyInto(&out.signCert)
 	return
 }

--- a/pkg/controller/remoteistio/remoteistio_controller.go
+++ b/pkg/controller/remoteistio/remoteistio_controller.go
@@ -110,6 +110,8 @@ func (r *ReconcileRemoteConfig) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, nil
 	}
 
+	// Set default values where not set
+	istiov1beta1.SetRemoteIstioDefaults(remoteConfig)
 	result, err := r.reconcile(remoteConfig)
 	if err != nil {
 		updateErr := r.updateRemoteConfigStatus(remoteConfig, istiov1beta1.ReconcileFailed, err.Error())

--- a/pkg/remoteclusters/reconcile_config.go
+++ b/pkg/remoteclusters/reconcile_config.go
@@ -19,9 +19,10 @@ package remoteclusters
 import (
 	"context"
 
-	istiov1beta1 "github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+
+	istiov1beta1 "github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
 )
 
 const ConfigName = "istio-config"
@@ -43,6 +44,8 @@ func (c *Cluster) reconcileConfig(remoteConfig *istiov1beta1.RemoteIstio) error 
 		istioConfig.Namespace = remoteConfig.Namespace
 		istioConfig.Spec.AutoInjectionNamespaces = remoteConfig.Spec.AutoInjectionNamespaces
 		istioConfig.Spec.ControlPlaneSecurityEnabled = remoteConfig.Spec.ControlPlaneSecurityEnabled
+		istioConfig.Spec.Citadel.ReplicaCount = remoteConfig.Spec.Citadel.ReplicaCount
+		istioConfig.Spec.SidecarInjector.ReplicaCount = remoteConfig.Spec.SidecarInjector.ReplicaCount
 		err = c.ctrlRuntimeClient.Create(context.TODO(), &istioConfig)
 		if err != nil {
 			return err
@@ -50,6 +53,8 @@ func (c *Cluster) reconcileConfig(remoteConfig *istiov1beta1.RemoteIstio) error 
 	} else {
 		istioConfig.Spec.AutoInjectionNamespaces = remoteConfig.Spec.AutoInjectionNamespaces
 		istioConfig.Spec.ControlPlaneSecurityEnabled = remoteConfig.Spec.ControlPlaneSecurityEnabled
+		istioConfig.Spec.Citadel.ReplicaCount = remoteConfig.Spec.Citadel.ReplicaCount
+		istioConfig.Spec.SidecarInjector.ReplicaCount = remoteConfig.Spec.SidecarInjector.ReplicaCount
 		err = c.ctrlRuntimeClient.Update(context.TODO(), &istioConfig)
 		if err != nil {
 			return err


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?

The PR implements the deployment replica count configuration option to the federated Istio reconciliation.

### Why?

The Istio deployments replica count were incorrectly set to 0 on the remote clusters.

- [x] Implementation tested
