### PR TITLE
Get desired replica count from HPA for deployments with HPA

### DIFF
--- a/pkg/k8sutil/hpa.go
+++ b/pkg/k8sutil/hpa.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"context"
+
+	autoscalev2beta1 "k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetHPAReplicaCountOrDefault get desired replica count from HPA if exists, returns the given default otherwise
+func GetHPAReplicaCountOrDefault(client client.Client, name types.NamespacedName, defaultReplicaCount int32) int32 {
+	var hpa autoscalev2beta1.HorizontalPodAutoscaler
+	err := client.Get(context.Background(), name, &hpa)
+	if err != nil {
+		return defaultReplicaCount
+	}
+
+	return hpa.Status.DesiredReplicas
+}

--- a/pkg/resources/pilot/deployment.go
+++ b/pkg/resources/pilot/deployment.go
@@ -24,8 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
 	"github.com/banzaicloud/istio-operator/pkg/resources/common"
 	"github.com/banzaicloud/istio-operator/pkg/resources/templates"
 	"github.com/banzaicloud/istio-operator/pkg/util"
@@ -39,7 +41,10 @@ func (r *Reconciler) deployment() runtime.Object {
 	return &appsv1.Deployment{
 		ObjectMeta: templates.ObjectMeta(deploymentName, util.MergeLabels(pilotLabels, labelSelector), r.Config),
 		Spec: appsv1.DeploymentSpec{
-			Replicas: util.IntPointer(r.Config.Spec.Pilot.ReplicaCount),
+			Replicas: util.IntPointer(k8sutil.GetHPAReplicaCountOrDefault(r.Client, types.NamespacedName{
+				Name:      hpaName,
+				Namespace: r.Config.Namespace,
+			}, r.Config.Spec.Pilot.ReplicaCount)),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: util.MergeLabels(appLabels, labelSelector),
 			},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #73 
| License         | Apache 2.0


### What's in this PR?

The desired replica count of a deployment must come from the HPA if there is related one to prevent the reconciliation reverting the HPA change made.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
