### PR TITLE
Fix '--watch-created-resources-events' flag

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,4 +22,4 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
-        - --watch-created-resources-events=false
+        - "--watch-created-resources-events=false"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

After a simple `make deploy` (using the latest `banzaicloud/istio-operator` image) the `manager` container in the `istio-operator-controller-manager-0` pod was failing. The error was the following: 
`$ kubectl -n=istio-system logs istio-operator-controller-manager-0 manager`
`flag provided but not defined: -watch-created-resources-events`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested