### PR TITLE
Bump default Istio version to 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you are willing to kickstart your Istio experience using Pipeline, check out 
 
 ## Installation
 
-The operator (`release-1.1` branch) installs the 1.1.0 version of Istio, and can run on Minikube v0.33.1+ and Kubernetes 1.10.0+.
+The operator (`release-1.1` branch) installs the 1.1.1 version of Istio, and can run on Minikube v0.33.1+ and Kubernetes 1.10.0+.
 
 As a pre-requisite it needs a Kubernetes cluster (you can create one using [Pipeline](https://github.com/banzaicloud/pipeline)).
 

--- a/config/samples/istio_v1beta1_istio.yaml
+++ b/config/samples/istio_v1beta1_istio.yaml
@@ -14,16 +14,16 @@ spec:
   sds:
     enabled: false
   pilot:
-    image: "docker.io/istio/pilot:1.1.0"
+    image: "docker.io/istio/pilot:1.1.1"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
     traceSampling: 1.0
   citadel:
-    image: "docker.io/istio/citadel:1.1.0"
+    image: "docker.io/istio/citadel:1.1.1"
     replicaCount: 1
   galley:
-    image: "docker.io/istio/galley:1.1.0"
+    image: "docker.io/istio/galley:1.1.1"
     replicaCount: 1
   gateways:
     ingress:
@@ -43,22 +43,22 @@ spec:
     k8singress:
       enabled: false
   mixer:
-    image: "docker.io/istio/mixer:1.1.0"
+    image: "docker.io/istio/mixer:1.1.1"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
   sidecarInjector:
-    image: "docker.io/istio/sidecar_injector:1.1.0"
+    image: "docker.io/istio/sidecar_injector:1.1.1"
     replicaCount: 1
     rewriteAppHTTPProbe: true
   nodeAgent:
     enabled: false
-    image: "docker.io/istio/node-agent-k8s:1.1.0"
+    image: "docker.io/istio/node-agent-k8s:1.1.1"
   proxy:
-    image: "docker.io/istio/proxyv2:1.1.0"
+    image: "docker.io/istio/proxyv2:1.1.1"
     enableCoreDump: false
   proxyInit:
-    image: "docker.io/istio/proxy_init:1.1.0"
+    image: "docker.io/istio/proxy_init:1.1.1"
   defaultPodDisruptionBudget:
     enabled: true
   outboundTrafficPolicy:

--- a/config/samples/istio_v1beta1_istio_sds_auth.yaml
+++ b/config/samples/istio_v1beta1_istio_sds_auth.yaml
@@ -17,16 +17,16 @@ spec:
     useTrustworthyJwt: false
     useNormalJwt: true
   pilot:
-    image: "docker.io/istio/pilot:1.1.0"
+    image: "docker.io/istio/pilot:1.1.1"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
     traceSampling: 1.0
   citadel:
-    image: "docker.io/istio/citadel:1.1.0"
+    image: "docker.io/istio/citadel:1.1.1"
     replicaCount: 1
   galley:
-    image: "docker.io/istio/galley:1.1.0"
+    image: "docker.io/istio/galley:1.1.1"
     replicaCount: 1
   gateways:
     ingress:
@@ -37,7 +37,7 @@ spec:
       serviceLabels: {}
       sds:
         enabled: true
-        image: "docker.io/istio/node-agent-k8s:1.1.0"
+        image: "docker.io/istio/node-agent-k8s:1.1.1"
     egress:
       replicaCount: 1
       minReplicas: 1
@@ -47,21 +47,21 @@ spec:
     k8singress:
       enabled: false
   mixer:
-    image: "docker.io/istio/mixer:1.1.0"
+    image: "docker.io/istio/mixer:1.1.1"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
   sidecarInjector:
-    image: "docker.io/istio/sidecar_injector:1.1.0"
+    image: "docker.io/istio/sidecar_injector:1.1.1"
     replicaCount: 1
   nodeAgent:
     enabled: true
-    image: "docker.io/istio/node-agent-k8s:1.1.0"
+    image: "docker.io/istio/node-agent-k8s:1.1.1"
   proxy:
-    image: "docker.io/istio/proxyv2:1.1.0"
+    image: "docker.io/istio/proxyv2:1.1.1"
     enableCoreDump: false
   proxyInit:
-    image: "docker.io/istio/proxy_init:1.1.0"
+    image: "docker.io/istio/proxy_init:1.1.1"
   defaultPodDisruptionBudget:
     enabled: true
   outboundTrafficPolicy:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,11 +3,11 @@ Released:
 - [x] - Install Istio
 - [x] - Enable global mTLS
 - [x] - Federation, flat
+- [x] - Istio 1.1.1 support
 
 Under development (next release)
 
 - [x] - Federation, gateway
-- [x] - Istio 1.1.0 support
 - [x] - Configurable node affinity
 
 Short term roadmap

--- a/pkg/apis/istio/v1beta1/defaults.go
+++ b/pkg/apis/istio/v1beta1/defaults.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	defaultImageHub                  = "docker.io/istio"
-	defaultImageVersion              = "1.1.0"
+	defaultImageVersion              = "1.1.1"
 	defaultPilotImage                = defaultImageHub + "/" + "pilot" + ":" + defaultImageVersion
 	defaultCitadelImage              = defaultImageHub + "/" + "citadel" + ":" + defaultImageVersion
 	defaultGalleyImage               = defaultImageHub + "/" + "galley" + ":" + defaultImageVersion

--- a/pkg/resources/gateways/deployment.go
+++ b/pkg/resources/gateways/deployment.go
@@ -231,7 +231,8 @@ func (r *Reconciler) volumeMounts(gw string, gwConfig *istiov1beta1.GatewayConfi
 	if r.Config.Spec.SDS.Enabled {
 		vms = append(vms, apiv1.VolumeMount{
 			Name:      "sdsudspath",
-			MountPath: "/var/run/sds",
+			MountPath: "/var/run/sds/uds_path",
+			ReadOnly:  true,
 		})
 		if r.Config.Spec.SDS.UseTrustworthyJwt {
 			vms = append(vms, apiv1.VolumeMount{
@@ -283,12 +284,12 @@ func (r *Reconciler) volumes(gw string, gwConfig *istiov1beta1.GatewayConfigurat
 		},
 	}
 	if r.Config.Spec.SDS.Enabled {
-		hostPathType := apiv1.HostPathUnset
+		hostPathType := apiv1.HostPathSocket
 		volumes = append(volumes, apiv1.Volume{
 			Name: "sdsudspath",
 			VolumeSource: apiv1.VolumeSource{
 				HostPath: &apiv1.HostPathVolumeSource{
-					Path: "/var/run/sds",
+					Path: "/var/run/sds/uds_path",
 					Type: &hostPathType,
 				},
 			},

--- a/pkg/resources/sidecarinjector/configmap.go
+++ b/pkg/resources/sidecarinjector/configmap.go
@@ -267,8 +267,9 @@ func (r *Reconciler) volumeMounts() string {
     name: istio-certs
     readOnly: true`
 	}
-	vms := `- mountPath: /var/run/sds
-    name: sds-uds-path`
+	vms := `- mountPath: /var/run/sds/uds_path
+    name: sds-uds-path
+	readOnly: true`
 	if r.Config.Spec.SDS.UseTrustworthyJwt {
 		vms = vms + `
   - mountPath: /var/run/secrets/tokens
@@ -296,7 +297,8 @@ func (r *Reconciler) volumes() string {
 	}
 	volumes := `- name: sds-uds-path
   hostPath:
-    path: /var/run/sds`
+    path: /var/run/sds/uds_path
+	type: Socket`
 	if r.Config.Spec.SDS.UseTrustworthyJwt {
 		volumes = volumes + `
 - name: istio-token


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

I compared the helm chart related changes between tag 1.1.0 and 1.1.1 in the [Istio repo](https://github.com/istio/istio/compare/1.1.0...1.1.1?diff=split). The only relevant change seemed to be introduced by this [commit](https://github.com/istio/istio/commit/8f42a40e73c98871d41f85b5d9ec6ae6dbf18ee4).


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested (on GKE, all Istio components were created successfully, BookInfo app worked)