### PR TITLE
Add CNI support to RemoteIstio

### DIFF
--- a/docs/federation/example/README.md
+++ b/docs/federation/example/README.md
@@ -9,8 +9,8 @@
 ### Create two GKE clusters with IP Alias feature to support flat networking
 
 ```bash
-gcloud container clusters create k8s-central --enable-ip-alias --zone europe-west1-b --machine-type n1-standard-2 --num-nodes=1 --preemptible --async
-gcloud container clusters create k8s-remote-1 --enable-ip-alias --zone us-central1-a --machine-type n1-standard-2 --num-nodes=1 --preemptible --async
+gcloud container clusters create k8s-central --enable-ip-alias --zone europe-west1-b --machine-type n1-standard-2 --num-nodes=1 --preemptible --async --enable-network-policy
+gcloud container clusters create k8s-remote-1 --enable-ip-alias --zone us-central1-a --machine-type n1-standard-2 --num-nodes=1 --preemptible --async --enable-network-policy
 ```
 
 Wait for the clusters getting into `RUNNING` state and get the credentials for them

--- a/pkg/remoteclusters/reconcile_remote_istio.go
+++ b/pkg/remoteclusters/reconcile_remote_istio.go
@@ -20,6 +20,7 @@ import (
 	istiov1beta1 "github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
 	"github.com/banzaicloud/istio-operator/pkg/resources"
 	"github.com/banzaicloud/istio-operator/pkg/resources/citadel"
+	"github.com/banzaicloud/istio-operator/pkg/resources/cni"
 	"github.com/banzaicloud/istio-operator/pkg/resources/common"
 	"github.com/banzaicloud/istio-operator/pkg/resources/nodeagent"
 	"github.com/banzaicloud/istio-operator/pkg/resources/sidecarinjector"
@@ -34,6 +35,7 @@ func (c *Cluster) reconcileComponents(remoteConfig *istiov1beta1.RemoteIstio, is
 			DeployMeshPolicy: false,
 		}, c.ctrlRuntimeClient, c.dynamicClient, c.istioConfig),
 		sidecarinjector.New(c.ctrlRuntimeClient, c.istioConfig),
+		cni.New(c.ctrlRuntimeClient, c.istioConfig),
 	}
 
 	if c.istioConfig.Spec.NodeAgent.Enabled {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


- CNI support for RemoteIstio resources
- enable network-policy for clusters in the remote example docs

### Checklist

- [x] Implementation tested
