### PR TITLE
HotFix: Fix indenting

### DIFF
--- a/pkg/resources/sidecarinjector/configmap.go
+++ b/pkg/resources/sidecarinjector/configmap.go
@@ -269,7 +269,7 @@ func (r *Reconciler) volumeMounts() string {
 	}
 	vms := `- mountPath: /var/run/sds/uds_path
     name: sds-uds-path
-	readOnly: true`
+    readOnly: true`
 	if r.Config.Spec.SDS.UseTrustworthyJwt {
 		vms = vms + `
   - mountPath: /var/run/secrets/tokens
@@ -298,7 +298,7 @@ func (r *Reconciler) volumes() string {
 	volumes := `- name: sds-uds-path
   hostPath:
     path: /var/run/sds/uds_path
-	type: Socket`
+    type: Socket`
 	if r.Config.Spec.SDS.UseTrustworthyJwt {
 		volumes = volumes + `
 - name: istio-token


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fix an indenting bug I introduced in #147, precisely [here](https://github.com/banzaicloud/istio-operator/pull/147/files#diff-e3f96edbb89da817fba24b85a5088356R272) and [here](https://github.com/banzaicloud/istio-operator/pull/147/files#diff-e3f96edbb89da817fba24b85a5088356R301). When Kubernetes tried to create BookInfo app pods when using the [istio_v1beta1_istio_sds_auth.yaml](https://github.com/banzaicloud/istio-operator/blob/release-1.1/config/samples/istio_v1beta1_istio_sds_auth.yaml), I got the following error: `Error creating: Internal error occurred: admission webhook "sidecar-injector.istio.io" denied the request: error converting YAML to JSON: yaml: line 128: found a tab character that violates indentation`

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

No tag was pushed containing the earlier PR merge commit, so fortunately there is no need to push a new tag.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested