### PR TITLE
save generated webhook server cert to disk instead of k8s secret

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -41,10 +41,3 @@ patches:
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
 - manager_role_patch.yaml
-
-vars:
-- name: WEBHOOK_SECRET_NAME
-  objref:
-    kind: Secret
-    name: webhook-server-secret
-    apiVersion: v1

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,8 +44,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: SECRET_NAME
-            value: $(WEBHOOK_SECRET_NAME)
         resources:
           limits:
             cpu: 100m
@@ -57,19 +55,4 @@ spec:
         - containerPort: 9876
           name: webhook-server
           protocol: TCP
-        volumeMounts:
-        - mountPath: /tmp/cert
-          name: cert
-          readOnly: true
       terminationGracePeriodSeconds: 10
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: webhook-server-secret
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: webhook-server-secret
-  namespace: system

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -20,7 +20,6 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -38,16 +37,11 @@ func add(mgr manager.Manager) error {
 
 	name := "istio-operator-webhook"
 	namespace := "istio-system"
-	secretName := "istio-operator-webhook-server-secret"
 
 	svr, err := webhook.NewServer(name, mgr, webhook.ServerOptions{
 		CertDir: "/tmp/cert",
 		BootstrapOptions: &webhook.BootstrapOptions{
 			ValidatingWebhookConfigName: name,
-			Secret: &types.NamespacedName{
-				Namespace: namespace,
-				Name:      secretName,
-			},
 			Service: &webhook.Service{
 				Namespace: namespace,
 				Name:      name,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### What's in this PR?

It backports webhook cert handling from release-1.1

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
