### PR TITLE
Fallback to `Update` if status subresource feature is disabled

### DIFF
--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -238,6 +238,9 @@ func (r *ReconcileConfig) updateStatus(config *istiov1beta1.Istio, status istiov
 	config.Status.Status = status
 	config.Status.ErrorMessage = errorMessage
 	err := r.Status().Update(context.Background(), config)
+	if k8serrors.IsNotFound(err) {
+		err = r.Update(context.Background(), config)
+	}
 	if err != nil {
 		if !k8serrors.IsConflict(err) {
 			return emperror.Wrapf(err, "could not update Istio state to '%s'", status)
@@ -252,6 +255,9 @@ func (r *ReconcileConfig) updateStatus(config *istiov1beta1.Istio, status istiov
 		config.Status.Status = status
 		config.Status.ErrorMessage = errorMessage
 		err = r.Status().Update(context.Background(), config)
+		if k8serrors.IsNotFound(err) {
+			err = r.Update(context.Background(), config)
+		}
 		if err != nil {
 			return emperror.Wrapf(err, "could not update Istio state to '%s'", status)
 		}

--- a/pkg/controller/remoteistio/remoteistio_controller.go
+++ b/pkg/controller/remoteistio/remoteistio_controller.go
@@ -220,7 +220,9 @@ func (r *ReconcileRemoteConfig) updateRemoteConfigStatus(remoteConfig *istiov1be
 	remoteConfig.Status.Status = status
 	remoteConfig.Status.ErrorMessage = errorMessage
 	err := r.Status().Update(context.Background(), remoteConfig)
-
+	if k8serrors.IsNotFound(err) {
+		err = r.Update(context.Background(), remoteConfig)
+	}
 	if err != nil {
 		if !k8serrors.IsConflict(err) {
 			return emperror.Wrapf(err, "could not update remote Istio state to '%s'", status)
@@ -236,6 +238,9 @@ func (r *ReconcileRemoteConfig) updateRemoteConfigStatus(remoteConfig *istiov1be
 		remoteConfig.Status.ErrorMessage = errorMessage
 
 		err = r.Status().Update(context.Background(), remoteConfig)
+		if k8serrors.IsNotFound(err) {
+			err = r.Update(context.Background(), remoteConfig)
+		}
 		if err != nil {
 			return emperror.Wrapf(err, "could not update remoteconfig status to '%s'", status)
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

Implements fallback to update the whole resource if the status subresource feature is disabled.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
