### PR TITLE
Remote Istio and owner matcher fixes

### DIFF
--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -512,7 +512,7 @@ func initWatches(c controller.Controller, scheme *runtime.Scheme, watchCreatedRe
 	objectMatcher := objectmatch.New(logf.NewDelegatingLogger(logf.NullLogger{}))
 
 	// Initialize owner matcher
-	ownerMatcher := k8sutil.NewOwnerReferenceMatcher(&istiov1beta1.Istio{}, true, scheme)
+	ownerMatcher := k8sutil.NewOwnerReferenceMatcher(&istiov1beta1.Istio{TypeMeta: metav1.TypeMeta{Kind: "Istio", APIVersion: "istio.banzaicloud.io/v1beta1"}}, true, scheme)
 
 	// Watch for changes to resources managed by the operator
 	for _, t := range []runtime.Object{

--- a/pkg/controller/remoteistio/remoteistio_controller.go
+++ b/pkg/controller/remoteistio/remoteistio_controller.go
@@ -168,6 +168,11 @@ func (r *ReconcileRemoteConfig) Reconcile(request reconcile.Request) (reconcile.
 				}
 			}
 
+			err = r.remoteClustersMgr.Delete(cluster)
+			if err != nil {
+				return reconcile.Result{}, emperror.Wrap(err, "could not remove cluster from manager")
+			}
+
 			err = r.labelSecret(client.ObjectKey{
 				Name:      remoteConfig.GetName(),
 				Namespace: remoteConfig.GetNamespace(),

--- a/pkg/k8sutil/owner.go
+++ b/pkg/k8sutil/owner.go
@@ -63,7 +63,7 @@ func (e *OwnerReferenceMatcher) Match(object runtime.Object) (bool, metav1.Objec
 			return false, o, emperror.WrapWith(err, "could not parse api version", "apiVersion", owner.APIVersion)
 		}
 
-		if owner.UID == e.ownerMeta.GetUID() && owner.Kind == e.ownerTypeGroupKind.Kind && groupVersion.Group == e.ownerTypeGroupKind.Group {
+		if (owner.UID == "" || (owner.UID != "" && owner.UID == e.ownerMeta.GetUID())) && owner.Kind == e.ownerTypeGroupKind.Kind && groupVersion.Group == e.ownerTypeGroupKind.Group {
 			return true, o, nil
 		}
 	}

--- a/pkg/remoteclusters/manager.go
+++ b/pkg/remoteclusters/manager.go
@@ -49,6 +49,15 @@ func (m *Manager) Add(cluster *Cluster) error {
 	return nil
 }
 
+func (m *Manager) Delete(cluster *Cluster) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.clusters, cluster.GetName())
+
+	return nil
+}
+
 func (m *Manager) Get(name string) (*Cluster, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

Removal of a remote istio was not properly handled, this PR fixes that issue.

The owner matcher didn't properly match the object because of a wrong uuid comparison, that was fixed as well.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
