### PR TITLE
Only wait for ingress ip if ingress enabled

### DIFF
--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -284,17 +284,18 @@ func (r *ReconcileConfig) reconcile(logger logr.Logger, config *istiov1beta1.Ist
 		}
 	}
 
-	ingressGatewayAddress, err := r.getIngressGatewayAddress(config, logger)
-	if err != nil {
-		log.Info(err.Error())
-		updateStatus(r.Client, config, istiov1beta1.ReconcileFailed, err.Error(), logger)
-		return reconcile.Result{
-			Requeue:      true,
-			RequeueAfter: time.Duration(30) * time.Second,
-		}, nil
+	if util.PointerToBool(config.Spec.Gateways.Enabled) && util.PointerToBool(config.Spec.Gateways.IngressConfig.Enabled) {
+		ingressGatewayAddress, err := r.getIngressGatewayAddress(config, logger)
+		if err != nil {
+			log.Info(err.Error())
+			updateStatus(r.Client, config, istiov1beta1.ReconcileFailed, err.Error(), logger)
+			return reconcile.Result{
+				Requeue:      true,
+				RequeueAfter: time.Duration(30) * time.Second,
+			}, nil
+		}
+		config.Status.GatewayAddress = ingressGatewayAddress
 	}
-
-	config.Status.GatewayAddress = ingressGatewayAddress
 
 	err = updateStatus(r.Client, config, istiov1beta1.Available, "", logger)
 	if err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

The operator should wait for the ingress gateway address only if ingress gateway is enabled.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
