### PR TITLE
Reconcile coreDNS configmap to support .global

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -269,6 +269,17 @@
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:864d011b025c37bb9833ebb11c22fe567021967a07a16df08623a328bb6e58e0"
+  name = "github.com/mholt/caddy"
+  packages = [
+    "caddyfile",
+    "telemetry",
+  ]
+  pruneopts = "T"
+  revision = "15fecbc16151308959674a5ce3843efb9e66bd5f"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:33422d238f147d247752996a26574ac48dcf472976eda7f5134015f06bf16563"
   name = "github.com/modern-go/concurrent"
   packages = ["."]
@@ -962,11 +973,11 @@
   input-imports = [
     "github.com/banzaicloud/k8s-objectmatcher",
     "github.com/emicklei/go-restful",
-    "github.com/evanphx/json-patch",
     "github.com/ghodss/yaml",
     "github.com/go-logr/logr",
     "github.com/gofrs/uuid",
     "github.com/goph/emperror",
+    "github.com/mholt/caddy/caddyfile",
     "github.com/onsi/ginkgo",
     "github.com/onsi/gomega",
     "github.com/pkg/errors",
@@ -991,7 +1002,6 @@
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/runtime",
-    "k8s.io/apimachinery/pkg/util/strategicpatch",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -74,9 +74,9 @@ version="v1.4.7"
   revision = "d082d5923d3cc0bfbb066ee5fbdea3d0ca79acf8"
 
 [[constraint]]
-  name = "github.com/evanphx/json-patch"
-  version = "4.1.0"
-
-[[constraint]]
   branch = "master"
   name = "github.com/banzaicloud/k8s-objectmatcher"
+
+[[constraint]]
+  name = "github.com/mholt/caddy"
+  version = "1.0.0"

--- a/pkg/resources/istiocoredns/coredns.go
+++ b/pkg/resources/istiocoredns/coredns.go
@@ -18,11 +18,13 @@ package istiocoredns
 
 import (
 	"context"
-	"fmt"
+	"encoding/json"
 	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/goph/emperror"
+	"github.com/mholt/caddy/caddyfile"
+	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -45,37 +47,47 @@ func (r *Reconciler) reconcileCoreDNSConfigMap(log logr.Logger, desiredState k8s
 		return emperror.Wrap(err, "could not get coredns configmap")
 	}
 
-	coreFile := cm.Data["CoreFile"]
-
-	var svc apiv1.Service
-	err = r.Client.Get(context.Background(), types.NamespacedName{
-		Name:      serviceName,
-		Namespace: r.Config.Namespace,
-	}, &svc)
-	if err != nil {
-		return emperror.Wrap(err, "could not get Istio coreDNS service")
-	}
-	clusterIP := []string{svc.Spec.ClusterIP}
-	global53 := fmt.Sprintf(`global:53 {
-			errors
-			cache 30
-			proxy . %s
-			}))`, clusterIP)
+	corefile := cm.Data["Corefile"]
+	desiredCorefile := corefile
+	clusterIP := ""
 
 	if desiredState == k8sutil.DesiredStatePresent {
-		if !strings.Contains(coreFile, global53) {
-			coreFile += global53
+		var svc apiv1.Service
+		err = r.Client.Get(context.Background(), types.NamespacedName{
+			Name:      serviceName,
+			Namespace: r.Config.Namespace,
+		}, &svc)
+		if err != nil {
+			return emperror.Wrap(err, "could not get Istio coreDNS service")
+		}
+		clusterIP = svc.Spec.ClusterIP
+	}
+
+	config := caddyfile.EncodedServerBlock{
+		Keys: []string{"global:53"},
+		Body: [][]interface{}{
+			{"errors"},
+			{"cache", "30"},
+			{"proxy", ".", clusterIP},
+		},
+	}
+
+	if desiredState == k8sutil.DesiredStatePresent {
+		desiredCorefile, err = r.updateCorefile([]byte(corefile), config, false)
+		if err != nil {
+			return emperror.Wrap(err, "could not add config for .global to Corefile")
 		}
 	} else if desiredState == k8sutil.DesiredStateAbsent {
-		if strings.Contains(coreFile, global53) {
-			strings.Replace(coreFile, global53, "", -1)
+		desiredCorefile, err = r.updateCorefile([]byte(corefile), config, true)
+		if err != nil {
+			return emperror.Wrap(err, "could not remove config for .global from Corefile")
 		}
 	}
 
 	if cm.Data == nil {
 		cm.Data = make(map[string]string, 0)
 	}
-	cm.Data["CoreFile"] = coreFile
+	cm.Data["Corefile"] = desiredCorefile
 
 	err = r.Client.Update(context.Background(), &cm)
 	if err != nil {
@@ -83,4 +95,55 @@ func (r *Reconciler) reconcileCoreDNSConfigMap(log logr.Logger, desiredState k8s
 	}
 
 	return nil
+}
+
+func (r *Reconciler) updateCorefile(corefile []byte, config caddyfile.EncodedServerBlock, remove bool) (string, error) {
+	corefileJSONData, err := caddyfile.ToJSON(corefile)
+	if err != nil {
+		return "", emperror.Wrap(err, "could not convert Corefile to JSON data")
+	}
+
+	var corefileJSON caddyfile.EncodedCaddyfile
+	err = json.Unmarshal(corefileJSONData, &corefileJSON)
+	if err != nil {
+		return "", emperror.Wrap(err, "could not unmarshal JSON to EncodedCaddyfile")
+	}
+
+	if len(config.Keys) < 1 {
+		return "", errors.New("invalid .global config")
+	}
+
+	pos := -1
+	for i, block := range corefileJSON {
+		if len(block.Keys) < 1 {
+			continue
+		}
+		if block.Keys[0] == config.Keys[0] {
+			pos = i
+			break
+		}
+	}
+
+	if remove && pos > 0 {
+		corefileJSON = append(corefileJSON[:pos], corefileJSON[pos+1:]...)
+	} else {
+		if pos > 0 {
+			corefileJSON[pos] = config
+		} else {
+			corefileJSON = append(corefileJSON, config)
+		}
+	}
+
+	corefileData, err := json.Marshal(&corefileJSON)
+	if err != nil {
+		return "", emperror.Wrap(err, "could not marshal EncodedCaddyfile to JSON")
+	}
+
+	corefile, err = caddyfile.FromJSON(corefileData)
+	if err != nil {
+		return "", emperror.Wrap(err, "could not convert JSON to Caddyfile")
+	}
+
+	// convert tabs to spaces for properly display content in ConfigMap
+	return strings.Replace(string(corefile), "\t", "  ", -1), nil
 }

--- a/pkg/resources/istiocoredns/coredns.go
+++ b/pkg/resources/istiocoredns/coredns.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package istiocoredns
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/goph/emperror"
+	apiv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+)
+
+// Add/Remove global:53 to/from coredns configmap
+func (r *Reconciler) reconcileCoreDNSConfigMap(log logr.Logger, desiredState k8sutil.DesiredState) error {
+	var cm apiv1.ConfigMap
+
+	err := r.Client.Get(context.Background(), types.NamespacedName{
+		Name:      "coredns",
+		Namespace: "kube-system",
+	}, &cm)
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return emperror.Wrap(err, "could not get coredns configmap")
+	}
+
+	coreFile := cm.Data["CoreFile"]
+
+	var svc apiv1.Service
+	err = r.Client.Get(context.Background(), types.NamespacedName{
+		Name:      serviceName,
+		Namespace: r.Config.Namespace,
+	}, &svc)
+	if err != nil {
+		return emperror.Wrap(err, "could not get Istio coreDNS service")
+	}
+	clusterIP := []string{svc.Spec.ClusterIP}
+	global53 := fmt.Sprintf(`global:53 {
+			errors
+			cache 30
+			proxy . %s
+			}))`, clusterIP)
+
+	if desiredState == k8sutil.DesiredStatePresent {
+		if !strings.Contains(coreFile, global53) {
+			coreFile += global53
+		}
+	} else if desiredState == k8sutil.DesiredStateAbsent {
+		if strings.Contains(coreFile, global53) {
+			strings.Replace(coreFile, global53, "", -1)
+		}
+	}
+
+	if cm.Data == nil {
+		cm.Data = make(map[string]string, 0)
+	}
+	cm.Data["CoreFile"] = coreFile
+
+	err = r.Client.Update(context.Background(), &cm)
+	if err != nil {
+		return emperror.Wrap(err, "could not update coredns configmap")
+	}
+
+	return nil
+}

--- a/pkg/resources/istiocoredns/istiocoredns.go
+++ b/pkg/resources/istiocoredns/istiocoredns.go
@@ -86,9 +86,14 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		}
 	}
 
-	err := r.reconcileKubeDNSConfigMap(log, desiredState)
+	err := r.reconcileCoreDNSConfigMap(log, desiredState)
 	if err != nil {
-		return emperror.WrapWith(err, "failed to update dns config")
+		return emperror.WrapWith(err, "failed to update coredns configmap")
+	}
+
+	err = r.reconcileKubeDNSConfigMap(log, desiredState)
+	if err != nil {
+		return emperror.WrapWith(err, "failed to update kube-dns configmap")
 	}
 
 	log.Info("Reconciled")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | partially #212 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add support for CoreDNS config for [multi-mesh setup](https://istio.io/docs/setup/kubernetes/install/multicluster/gateways/#setup-dns).