### PR TITLE
Fix default operator image

### DIFF
--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -36,7 +36,7 @@ spec:
       containers:
       - command:
         - /manager
-        image: banzaicloud/istio-operator:latest
+        image: banzaicloud/istio-operator:latest-1.1
         imagePullPolicy: Always
         name: manager
         env:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The `latest` image was simply the most recently built image on DockerHub which means it could be an image built from the `release-1.0` branch. This could cause issues when we would like to use the latest image from the `release-1.1` branch (or `release-1.2` later on). Hence we now have `latest-1.0` and `latest-1.1` tags as well to have the newest versions for Istio 1.0.x and Istio 1.1.x as well.