### PR TITLE
Change Helm chart repo in README.md to relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ kubectl create -n istio-system -f config/samples/istio_v1beta1_istio.yaml
 
 ### Installation with Helm
 
-Alternatively, if you just can’t let go of Helm completely, you can deploy the operator using a Helm chart, which is available in the Banzai Cloud stable [Helm repo](https://github.com/banzaicloud/banzai-charts/tree/master/istio-operator):
+Alternatively, if you just can’t let go of Helm completely, you can deploy the operator using a Helm chart, which is available in the Banzai Cloud stable [Helm repo](deploy/charts/istio-operator):
 
 ```bash
 helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com/


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Change Helm chart repo url to relative path since the chart was moved to this repo (#239) and will be removed from [banzai-charts](https://github.com/banzaicloud/banzai-charts/pull/864) repo soon.