### PR TITLE
Objectmatcher upgrade and smaller fixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,12 +10,12 @@
   version = "v0.35.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:f5cb7e742fcf167ff7d2ac8ca6ebc7f797a04c98f2daac3de7d4323dbf3dccd7"
+  digest = "1:7e124da7e6600e670a4e44b363518ecd4fdd74cf84adf5bd00d99844702e3c9d"
   name = "github.com/banzaicloud/k8s-objectmatcher"
-  packages = ["."]
+  packages = ["patch"]
   pruneopts = "T"
-  revision = "5288f80397dd1d5c16ee4fcc7062b99322a17ca0"
+  revision = "1596e84aae2764cab454a32215e756bbbee3af5d"
+  version = "v0.1.1"
 
 [[projects]]
   branch = "master"
@@ -744,6 +744,7 @@
     "pkg/util/framer",
     "pkg/util/intstr",
     "pkg/util/json",
+    "pkg/util/jsonmergepatch",
     "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
@@ -971,7 +972,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/banzaicloud/k8s-objectmatcher",
+    "github.com/banzaicloud/k8s-objectmatcher/patch",
     "github.com/emicklei/go-restful",
     "github.com/ghodss/yaml",
     "github.com/go-logr/logr",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,9 +73,9 @@ version="v1.4.7"
   # revision for tag "kubernetes-1.12.3"
   revision = "d082d5923d3cc0bfbb066ee5fbdea3d0ca79acf8"
 
-[[constraint]]
-  branch = "master"
+[[override]]
   name = "github.com/banzaicloud/k8s-objectmatcher"
+  version = "0.1.1"
 
 [[constraint]]
   name = "github.com/mholt/caddy"

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	patch "github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/go-logr/logr"
 	"github.com/gofrs/uuid"
 	"github.com/goph/emperror"
@@ -64,7 +65,6 @@ import (
 	"github.com/banzaicloud/istio-operator/pkg/resources/pilot"
 	"github.com/banzaicloud/istio-operator/pkg/resources/sidecarinjector"
 	"github.com/banzaicloud/istio-operator/pkg/util"
-	objectmatch "github.com/banzaicloud/k8s-objectmatcher"
 )
 
 const finalizerID = "istio-operator.finializer.banzaicloud.io"
@@ -520,9 +520,6 @@ func initWatches(c controller.Controller, scheme *runtime.Scheme, watchCreatedRe
 		return nil
 	}
 
-	// Initialize object matcher
-	objectMatcher := objectmatch.New(logf.NewDelegatingLogger(logf.NullLogger{}))
-
 	// Initialize owner matcher
 	ownerMatcher := k8sutil.NewOwnerReferenceMatcher(&istiov1beta1.Istio{TypeMeta: metav1.TypeMeta{Kind: "Istio", APIVersion: "istio.banzaicloud.io/v1beta1"}}, true, scheme)
 
@@ -558,10 +555,10 @@ func initWatches(c controller.Controller, scheme *runtime.Scheme, watchCreatedRe
 				return true
 			},
 			UpdateFunc: func(e event.UpdateEvent) bool {
-				objectsEquals, err := objectMatcher.Match(e.ObjectOld, e.ObjectNew)
+				patchResult, err := patch.DefaultPatchMaker.Calculate(e.ObjectOld, e.ObjectNew)
 				if err != nil {
 					logger.Error(err, "could not match objects", "kind", e.ObjectOld.GetObjectKind())
-				} else if objectsEquals {
+				} else if patchResult.IsEmpty() {
 					return false
 				}
 				related, object, err := ownerMatcher.Match(e.ObjectNew)

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -48,13 +48,17 @@ func IntstrPointer(i int) *intstr.IntOrString {
 }
 
 func MergeLabels(l map[string]string, l2 map[string]string) map[string]string {
+	merged := make(map[string]string)
 	if l == nil {
 		l = make(map[string]string)
 	}
-	for lKey, lValue := range l2 {
-		l[lKey] = lValue
+	for lKey, lValue := range l {
+		merged[lKey] = lValue
 	}
-	return l
+	for lKey, lValue := range l2 {
+		merged[lKey] = lValue
+	}
+	return merged
 }
 
 func EmptyTypedStrSlice(s ...string) []interface{} {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Upgrade from the legacy version of the objectmatcher library to use the generic method for matching current and desired object states to decide whether an update is required or not.

Add explicit continue/return statements after object creation to make sure we don't end up trying to update a newly created object. Right now it's not an issue, but it can be if errors are not handled properly.

The PR also adds a small fix to avoid mutating the original map when called on MergeLabels as it resulted in unnecessary updates in certain cases.

### Why?
The legacy version was hard to maintain and came with hidden caveats and shortcomings.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
