### PR TITLE
Bump default Istio version to 1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you are willing to kickstart your Istio experience using Pipeline, check out 
 
 ## Installation
 
-The operator (`master` branch) installs the 1.0.8 version of Istio, and can run on Minikube v0.33.1+ and Kubernetes 1.10.0+.
+The operator (`master` branch) installs the 1.0.9 version of Istio, and can run on Minikube v0.33.1+ and Kubernetes 1.10.0+.
 
 As a pre-requisite it needs a Kubernetes cluster (you can create one using [Pipeline](https://github.com/banzaicloud/pipeline)).
 

--- a/config/samples/istio_v1beta1_istio.yaml
+++ b/config/samples/istio_v1beta1_istio.yaml
@@ -12,16 +12,16 @@ spec:
   - "default"
   controlPlaneSecurityEnabled: false
   pilot:
-    image: "istio/pilot:1.0.8"
+    image: "istio/pilot:1.0.9"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
     traceSampling: 1.0
   citadel:
-    image: "istio/citadel:1.0.8"
+    image: "istio/citadel:1.0.9"
     replicaCount: 1
   galley:
-    image: "istio/galley:1.0.8"
+    image: "istio/galley:1.0.9"
     replicaCount: 1
   gateways:
     ingress:
@@ -37,15 +37,15 @@ spec:
       serviceAnnotations: {}
       serviceLabels: {}
   mixer:
-    image: "istio/mixer:1.0.8"
+    image: "istio/mixer:1.0.9"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
   sidecarInjector:
-    image: "istio/sidecar_injector:1.0.8"
+    image: "istio/sidecar_injector:1.0.9"
     replicaCount: 1
   proxy:
-    image: "istio/proxyv2:1.0.8"
+    image: "istio/proxyv2:1.0.9"
   tracing:
     zipkin:
       address: zipkin.jaeger-system:9411

--- a/config/samples/istio_v1beta1_remoteistio.yaml
+++ b/config/samples/istio_v1beta1_remoteistio.yaml
@@ -22,10 +22,10 @@ spec:
     labelSelector: "app=jaeger"
   controlPlaneSecurityEnabled: true
   citadel:
-      image: "istio/citadel:1.0.8"
+      image: "istio/citadel:1.0.9"
       replicaCount: 1
   sidecarInjector:
-      image: "istio/sidecar_injector:1.0.8"
+      image: "istio/sidecar_injector:1.0.9"
       replicaCount: 1
   proxy:
-      image: "istio/proxyv2:1.0.8"
+      image: "istio/proxyv2:1.0.9"

--- a/pkg/apis/istio/v1beta1/defaults.go
+++ b/pkg/apis/istio/v1beta1/defaults.go
@@ -19,7 +19,7 @@ package v1beta1
 import "fmt"
 
 const (
-	defaultImageVersion         = "1.0.8"
+	defaultImageVersion         = "1.0.9"
 	defaultPilotImage           = "istio/pilot" + ":" + defaultImageVersion
 	defaultCitadelImage         = "istio/citadel" + ":" + defaultImageVersion
 	defaultGalleyImage          = "istio/galley" + ":" + defaultImageVersion

--- a/pkg/resources/sidecarinjector/configmap.go
+++ b/pkg/resources/sidecarinjector/configmap.go
@@ -48,7 +48,7 @@ func (r *Reconciler) siConfig() string {
 func (r *Reconciler) templateConfig() string {
 	return `initContainers:
 - name: istio-init
-  image: docker.io/istio/proxy_init:1.0.8
+  image: docker.io/istio/proxy_init:1.0.9
   args:
   - "-p"
   - [[ .MeshConfig.ProxyListenPort ]]
@@ -73,7 +73,7 @@ func (r *Reconciler) templateConfig() string {
   restartPolicy: Always
 containers:
 - name: istio-proxy
-  image: "[[ annotation .ObjectMeta ` + "`" + `sidecar.istio.io/proxyImage` + "`" + ` "docker.io/istio/proxyv2:1.0.8" ]]"
+  image: "[[ annotation .ObjectMeta ` + "`" + `sidecar.istio.io/proxyImage` + "`" + ` "docker.io/istio/proxyv2:1.0.9" ]]"
   ports:
   - containerPort: 15090
     protocol: TCP


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

Bumps default Istio version to 1.0.9
