### PR TITLE
Specify istio-init user explicitely (#249)

### DIFF
--- a/pkg/resources/sidecarinjector/configmap.go
+++ b/pkg/resources/sidecarinjector/configmap.go
@@ -84,6 +84,7 @@ func (r *Reconciler) proxyInitContainer() string {
   imagePullPolicy: ` + string(r.Config.Spec.ImagePullPolicy) + `
 ` + r.getFormattedResources(r.Config.Spec.SidecarInjector.Init.Resources, 2) + `
   securityContext:
+    runAsUser: 0
     capabilities:
       add:
       - NET_ADMIN


### PR DESCRIPTION
Signed-off-by: sebastien allamand <sebastien.allamand@orange.com>

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #249
| License         | Apache 2.0


### What's in this PR?

This PR goal it to configure explicitely the istio-init container with root userID so that it can do iptables.


### Why?

Without this, the container inherit the Pods capabilities and if it is configure to be nonRoot user, the istio-init container will fail

### Checklist

- [x] Implementation tested
