### PR TITLE
Make multi cluster telemetry optional to support upstream mixer

### DIFF
--- a/config/base/crds/istio_v1beta1_istio.yaml
+++ b/config/base/crds/istio_v1beta1_istio.yaml
@@ -283,6 +283,10 @@ spec:
                 minReplicas:
                   format: int32
                   type: integer
+                multiClusterSupport:
+                  description: Turn it on if you use mixer that supports multi cluster
+                    telemetry
+                  type: boolean
                 nodeSelector:
                   type: object
                 replicaCount:

--- a/pkg/apis/istio/v1beta1/istio_types.go
+++ b/pkg/apis/istio/v1beta1/istio_types.go
@@ -137,6 +137,8 @@ type MixerConfiguration struct {
 	NodeSelector map[string]string            `json:"nodeSelector,omitempty"`
 	Affinity     *corev1.Affinity             `json:"affinity,omitempty"`
 	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
+	// Turn it on if you use mixer that supports multi cluster telemetry
+	MultiClusterSupport *bool `json:"multiClusterSupport,omitempty"`
 }
 
 // InitCNIConfiguration defines config for the sidecar proxy init CNI plugin

--- a/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
@@ -634,6 +634,11 @@ func (in *MixerConfiguration) DeepCopyInto(out *MixerConfiguration) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.MultiClusterSupport != nil {
+		in, out := &in.MultiClusterSupport, &out.MultiClusterSupport
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this

Our own Mixer fork adds an additional `cluster_id` attribute to the incoming metrics to support proper multi cluster telemetry. This PR makes deployed Istio kubernetes CR (which configures the adapter that is responsible to enrich incoming telemetry data with K8s attributes) configurable.

### Why?

Right now the telemetry doesn't work well with upstream mixer, this PR fixes that bug.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
