### PR TITLE
Fix invalid GKE version in multimesh docs

### DIFF
--- a/docs/federation/multimesh/istio-gke-cluster.json
+++ b/docs/federation/multimesh/istio-gke-cluster.json
@@ -6,9 +6,9 @@
   "properties": {
     "gke": {
       "master": {
-        "version": "1.13.6-gke.0"
+        "version": "1.13"
       },
-      "nodeVersion": "1.13.6-gke.0",
+      "nodeVersion": "1.13",
       "nodePools": {
         "pool1": {
           "count": 1,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

The following GKE node version was used in a multi-mesh demo doc: `1.13.6-gke.0`. This version is not supported on GKE anymore, so the cluster creation failed.

Right now `1.13.6-gke.7` is supported. Instead of simply using `1.13.6-gke.7`, I propose to simply use `1.13` because in that case always the latest `1.13` version will be used automatically and it won't break in the future (only when `1.13` is unsupported altogether).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
