### PR TITLE
PSP support to release 1.2 branch

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -31,3 +31,10 @@ bases:
 bases:
   - github.com/banzaicloud/istio-operator/config/overlays/prometheus-scpraping-enabled?ref=release-1.2
 ```
+
+ - `psp`: besides the basic configs, add basic pod security policy for the operator and the Istio component pods
+
+```
+bases:
+  - github.com/banzaicloud/istio-operator/config/overlays/psp?ref=release-1.2
+```

--- a/config/overlays/psp/kustomization.yaml
+++ b/config/overlays/psp/kustomization.yaml
@@ -3,6 +3,8 @@ bases:
 
 namespace: istio-system
 
+namePrefix: istio-operator-
+
 resources:
 - resources/psp.yaml
 - resources/psp_role.yaml

--- a/config/overlays/psp/kustomization.yaml
+++ b/config/overlays/psp/kustomization.yaml
@@ -1,0 +1,9 @@
+bases:
+- ../../base
+
+namespace: istio-system
+
+resources:
+- resources/psp.yaml
+- resources/psp_role.yaml
+- resources/psp_role_binding.yaml

--- a/config/overlays/psp/resources/psp.yaml
+++ b/config/overlays/psp/resources/psp.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: istio-operator.allow-all
+spec:
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - secret
+  - configMap
+  - emptyDir

--- a/config/overlays/psp/resources/psp.yaml
+++ b/config/overlays/psp/resources/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: istio-operator.allow-all
+  name: psp-basic
 spec:
   fsGroup:
     rule: RunAsAny

--- a/config/overlays/psp/resources/psp_role.yaml
+++ b/config/overlays/psp/resources/psp_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp:istio-operator.allow-all
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - istio-operator.allow-all
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/config/overlays/psp/resources/psp_role.yaml
+++ b/config/overlays/psp/resources/psp_role.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: psp:istio-operator.allow-all
+  name: psp-basic
 rules:
 - apiGroups:
   - policy
   resourceNames:
-  - istio-operator.allow-all
+  - istio-operator-psp-basic
   resources:
   - podsecuritypolicies
   verbs:

--- a/config/overlays/psp/resources/psp_role_binding.yaml
+++ b/config/overlays/psp/resources/psp_role_binding.yaml
@@ -1,15 +1,31 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: psp:istio-operator.allow-all
+  name: psp-basic
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: psp:istio-operator.allow-all
+  name: psp-basic
 subjects:
   - kind: ServiceAccount
-    name: statefulset-controller
-    namespace: kube-system
+    name: istio-citadel-service-account
   - kind: ServiceAccount
-    name: replicaset-controller
-    namespace: kube-system
+    name: istio-galley-service-account
+  - kind: ServiceAccount
+    name: istio-egressgateway-service-account
+  - kind: ServiceAccount
+    name: istio-ingressgateway-service-account
+  - kind: ServiceAccount
+    name: istio-mixer-service-account
+  - kind: ServiceAccount
+    name: istio-operator-authproxy
+  - kind: ServiceAccount
+    name: istio-pilot-service-account
+  - kind: ServiceAccount
+    name: istio-sidecar-injector-service-account
+  - kind: ServiceAccount
+    name: istiocoredns-service-account
+  - kind: ServiceAccount
+    name: istio-nodeagent-service-account
+  - kind: ServiceAccount
+    name: default

--- a/config/overlays/psp/resources/psp_role_binding.yaml
+++ b/config/overlays/psp/resources/psp_role_binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: psp:istio-operator.allow-all
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: psp:istio-operator.allow-all
+subjects:
+  - kind: ServiceAccount
+    name: statefulset-controller
+    namespace: kube-system
+  - kind: ServiceAccount
+    name: replicaset-controller
+    namespace: kube-system

--- a/deploy/charts/istio-operator/README.md
+++ b/deploy/charts/istio-operator/README.md
@@ -42,3 +42,4 @@ Parameter | Description | Default
 `prometheusMetrics.authProxy.image.tag` | Auth proxy container image tag | `v0.4.0`
 `prometheusMetrics.authProxy.image.pullPolicy` | Auth proxy container image pull policy | `IfNotPresent`
 `rbac.enabled` | Create rbac service account and roles | `true`
+`rbac.psp.enabled` | Create pod security policy and binding | `false`

--- a/deploy/charts/istio-operator/templates/operator-psp-basic.yaml
+++ b/deploy/charts/istio-operator/templates/operator-psp-basic.yaml
@@ -2,7 +2,7 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: istio-operator.allow-all
+  name: {{ include "istio-operator.fullname" . }}-basic
   labels:
     app.kubernetes.io/name: {{ include "istio-operator.name" . }}
     helm.sh/chart: {{ include "istio-operator.chart" . }}
@@ -27,7 +27,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: psp:istio-operator.allow-all
+  name: psp:{{ include "istio-operator.fullname" . }}-basic
   labels:
     app.kubernetes.io/name: {{ include "istio-operator.name" . }}
     helm.sh/chart: {{ include "istio-operator.chart" . }}
@@ -39,7 +39,7 @@ rules:
 - apiGroups:
   - policy
   resourceNames:
-  - istio-operator.allow-all
+  - {{ include "istio-operator.fullname" . }}-basic
   resources:
   - podsecuritypolicies
   verbs:
@@ -48,7 +48,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: psp:istio-operator.allow-all
+  name: psp:{{ include "istio-operator.fullname" . }}-basic
   labels:
     app.kubernetes.io/name: {{ include "istio-operator.name" . }}
     helm.sh/chart: {{ include "istio-operator.chart" . }}
@@ -59,12 +59,33 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: psp:istio-operator.allow-all
+  name: psp:{{ include "istio-operator.fullname" . }}-basic
 subjects:
   - kind: ServiceAccount
-    name: statefulset-controller
-    namespace: kube-system
+    name: istio-citadel-service-account
+    namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
-    name: replicaset-controller
-    namespace: kube-system
+    name: istio-galley-service-account
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: istio-egressgateway-service-account
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: istio-ingressgateway-service-account
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: istio-mixer-service-account
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: istio-operator-authproxy
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: istio-pilot-service-account
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: istio-sidecar-injector-service-account
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: istio-operator-operator
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy/charts/istio-operator/templates/operator-psp-basic.yaml
+++ b/deploy/charts/istio-operator/templates/operator-psp-basic.yaml
@@ -86,6 +86,12 @@ subjects:
     name: istio-sidecar-injector-service-account
     namespace: {{ .Release.Namespace }}
   - kind: ServiceAccount
+    name: istiocoredns-service-account
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: istio-nodeagent-service-account
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
     name: istio-operator-operator
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy/charts/istio-operator/templates/operator-psp.yaml
+++ b/deploy/charts/istio-operator/templates/operator-psp.yaml
@@ -1,0 +1,70 @@
+{{- if and .Values.rbac.enabled .Values.rbac.psp.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: istio-operator.allow-all
+  labels:
+    app.kubernetes.io/name: {{ include "istio-operator.name" . }}
+    helm.sh/chart: {{ include "istio-operator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: operator
+spec:
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - secret
+  - configMap
+  - emptyDir
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp:istio-operator.allow-all
+  labels:
+    app.kubernetes.io/name: {{ include "istio-operator.name" . }}
+    helm.sh/chart: {{ include "istio-operator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: operator
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - istio-operator.allow-all
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: psp:istio-operator.allow-all
+  labels:
+    app.kubernetes.io/name: {{ include "istio-operator.name" . }}
+    helm.sh/chart: {{ include "istio-operator.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: psp:istio-operator.allow-all
+subjects:
+  - kind: ServiceAccount
+    name: statefulset-controller
+    namespace: kube-system
+  - kind: ServiceAccount
+    name: replicaset-controller
+    namespace: kube-system
+{{- end }}

--- a/deploy/charts/istio-operator/values.yaml
+++ b/deploy/charts/istio-operator/values.yaml
@@ -34,6 +34,11 @@ prometheusMetrics:
 ##
 rbac:
   enabled: true
+  ## Pod Security Policies
+  ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  ##
+  psp:
+    enabled: false
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #275 
| License         | Apache 2.0


### What's in this PR?

Adds PSP into the helm chart and an overlay config kustomize to support deployment to PSP enabled clusters. Cherry-picked from: #252.

### Why?

Without defined PSP the deployed pods and the operator itself cannot start on a cluster where PSP is enabled.
