### PR TITLE
Service upgrade and related object triggered reconcile fixes - v1.1

### DIFF
--- a/pkg/k8sutil/owner.go
+++ b/pkg/k8sutil/owner.go
@@ -63,7 +63,7 @@ func (e *OwnerReferenceMatcher) Match(object runtime.Object) (bool, metav1.Objec
 			return false, o, emperror.WrapWith(err, "could not parse api version", "apiVersion", owner.APIVersion)
 		}
 
-		if (owner.UID == "" || (owner.UID != "" && owner.UID == e.ownerMeta.GetUID())) && owner.Kind == e.ownerTypeGroupKind.Kind && groupVersion.Group == e.ownerTypeGroupKind.Group {
+		if (e.ownerMeta.GetUID() == "" || (e.ownerMeta.GetUID() != "" && owner.UID == e.ownerMeta.GetUID())) && owner.Kind == e.ownerTypeGroupKind.Kind && groupVersion.Group == e.ownerTypeGroupKind.Group {
 			return true, o, nil
 		}
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?

It fixes a bug which caused conflict during `Service` resource upgrades.
It also fixes owner matching in related object watchers to prevent unnecessary reconciles.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
