### PR TITLE
Support Istio 1.1.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you are willing to kickstart your Istio experience using Pipeline, check out 
 
 ## Installation
 
-The operator (`release-1.1` branch) installs the 1.1.13 version of Istio, and can run on Minikube v0.33.1+ and Kubernetes 1.10.0+.
+The operator (`release-1.1` branch) installs the 1.1.14 version of Istio, and can run on Minikube v0.33.1+ and Kubernetes 1.10.0+.
 
 As a pre-requisite it needs a Kubernetes cluster (you can create one using [Pipeline](https://github.com/banzaicloud/pipeline)).
 

--- a/config/samples/istio_v1beta1_istio.yaml
+++ b/config/samples/istio_v1beta1_istio.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   mtls: false
   includeIPRanges: "*"
   excludeIPRanges: ""
@@ -19,7 +19,7 @@ spec:
     enabled: false
   pilot:
     enabled: true
-    image: "docker.io/istio/pilot:1.1.13"
+    image: "docker.io/istio/pilot:1.1.14"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
@@ -30,10 +30,10 @@ spec:
         memory: 2048Mi
   citadel:
     enabled: true
-    image: "docker.io/istio/citadel:1.1.13"
+    image: "docker.io/istio/citadel:1.1.14"
   galley:
     enabled: true
-    image: "docker.io/istio/galley:1.1.13"
+    image: "docker.io/istio/galley:1.1.14"
     replicaCount: 1
   gateways:
     enabled: true
@@ -96,13 +96,13 @@ spec:
       enabled: false
   mixer:
     enabled: true
-    image: "docker.io/istio/mixer:1.1.13"
+    image: "docker.io/istio/mixer:1.1.14"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
   sidecarInjector:
     enabled: true
-    image: "docker.io/istio/sidecar_injector:1.1.13"
+    image: "docker.io/istio/sidecar_injector:1.1.14"
     replicaCount: 1
     rewriteAppHTTPProbe: true
     autoInjectionPolicyEnabled: true
@@ -116,9 +116,9 @@ spec:
           memory: 50Mi
   nodeAgent:
     enabled: false
-    image: "docker.io/istio/node-agent-k8s:1.1.13"
+    image: "docker.io/istio/node-agent-k8s:1.1.14"
   proxy:
-    image: "docker.io/istio/proxyv2:1.1.13"
+    image: "docker.io/istio/proxyv2:1.1.14"
     enableCoreDump: false
     resources:
       requests:
@@ -128,7 +128,7 @@ spec:
         cpu: 2000m
         memory: 1024Mi
   proxyInit:
-    image: "docker.io/istio/proxy_init:1.1.13"
+    image: "docker.io/istio/proxy_init:1.1.14"
   defaultPodDisruptionBudget:
     enabled: true
   outboundTrafficPolicy:

--- a/config/samples/istio_v1beta1_istio_cni.yaml
+++ b/config/samples/istio_v1beta1_istio_cni.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   mtls: false
   autoInjectionNamespaces:
   - "default"

--- a/config/samples/istio_v1beta1_istio_cni_gke.yaml
+++ b/config/samples/istio_v1beta1_istio_cni_gke.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   mtls: false
   autoInjectionNamespaces:
   - "default"

--- a/config/samples/istio_v1beta1_istio_meshexpansion.yaml
+++ b/config/samples/istio_v1beta1_istio_meshexpansion.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   autoInjectionNamespaces:
   - "default"
   useMCP: true

--- a/config/samples/istio_v1beta1_istio_minimal.yaml
+++ b/config/samples/istio_v1beta1_istio_minimal.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   mtls: false
   autoInjectionNamespaces:
   - "default"

--- a/config/samples/istio_v1beta1_istio_multimesh.yaml
+++ b/config/samples/istio_v1beta1_istio_multimesh.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: multimesh
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   autoInjectionNamespaces:
   - "default"
   useMCP: true

--- a/config/samples/istio_v1beta1_istio_nodeaffinities.yaml
+++ b/config/samples/istio_v1beta1_istio_nodeaffinities.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   mtls: false
   includeIPRanges: "*"
   excludeIPRanges: ""
@@ -16,7 +16,7 @@ spec:
     enabled: false
   pilot:
     enabled: true
-    image: "docker.io/istio/pilot:1.1.13"
+    image: "docker.io/istio/pilot:1.1.14"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
@@ -30,10 +30,10 @@ spec:
       tolerationSeconds: 6000
   citadel:
     enabled: true
-    image: "docker.io/istio/citadel:1.1.13"
+    image: "docker.io/istio/citadel:1.1.14"
   galley:
     enabled: true
-    image: "docker.io/istio/galley:1.1.13"
+    image: "docker.io/istio/galley:1.1.14"
     replicaCount: 1
   gateways:
     enabled: true
@@ -89,24 +89,24 @@ spec:
       enabled: false
   mixer:
     enabled: true
-    image: "docker.io/istio/mixer:1.1.13"
+    image: "docker.io/istio/mixer:1.1.14"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
   sidecarInjector:
     enabled: true
-    image: "docker.io/istio/sidecar_injector:1.1.13"
+    image: "docker.io/istio/sidecar_injector:1.1.14"
     replicaCount: 1
     rewriteAppHTTPProbe: true
     autoInjectionPolicyEnabled: true
   nodeAgent:
     enabled: false
-    image: "docker.io/istio/node-agent-k8s:1.1.13"
+    image: "docker.io/istio/node-agent-k8s:1.1.14"
   proxy:
-    image: "docker.io/istio/proxyv2:1.1.13"
+    image: "docker.io/istio/proxyv2:1.1.14"
     enableCoreDump: false
   proxyInit:
-    image: "docker.io/istio/proxy_init:1.1.13"
+    image: "docker.io/istio/proxy_init:1.1.14"
   defaultPodDisruptionBudget:
     enabled: true
   outboundTrafficPolicy:

--- a/config/samples/istio_v1beta1_istio_sds_auth.yaml
+++ b/config/samples/istio_v1beta1_istio_sds_auth.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   mtls: true
   autoInjectionNamespaces:
   - "default"
@@ -20,7 +20,7 @@ spec:
       enabled: true
       sds:
         enabled: true
-        image: "docker.io/istio/node-agent-k8s:1.1.13"
+        image: "docker.io/istio/node-agent-k8s:1.1.14"
         resources:
           requests:
             cpu: 100m
@@ -30,4 +30,4 @@ spec:
             memory: 1024Mi
   nodeAgent:
     enabled: true
-    image: "docker.io/istio/node-agent-k8s:1.1.13"
+    image: "docker.io/istio/node-agent-k8s:1.1.14"

--- a/docs/federation/gateway/samples/istio-multicluster-cr.yaml
+++ b/docs/federation/gateway/samples/istio-multicluster-cr.yaml
@@ -3,7 +3,7 @@ kind: Istio
 metadata:
   name: gateway-multicluster
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   autoInjectionNamespaces:
   - "default"
   mtls: true

--- a/docs/federation/multimesh/istio-multimesh-cr.yaml
+++ b/docs/federation/multimesh/istio-multimesh-cr.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: multimesh
 spec:
-  version: "1.1.13"
+  version: "1.1.14"
   autoInjectionNamespaces:
   - "default"
   useMCP: true

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -4,10 +4,10 @@ The steps are listed in this doc to perform an Istio version upgrade with the op
 
 ## Istio Control Plane Upgrade
 
-Let us suppose that we have a [Kubernetes](https://kubernetes.io/) cluster with Istio 1.0.7, and we would like to upgrade our Istio components to Istio version 1.1.13. Here are the steps we need to perform to accomplish this with the operator:
+Let us suppose that we have a [Kubernetes](https://kubernetes.io/) cluster with Istio 1.0.7, and we would like to upgrade our Istio components to Istio version 1.1.14. Here are the steps we need to perform to accomplish this with the operator:
 
 1. Deploy a version of the operator which supports Istio 1.1.x
-2. Apply a [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) using Istio 1.1.13 components
+2. Apply a [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) using Istio 1.1.14 components
 
 What happens is that once the operator discerns that the Custom Resource it's watching has changed, it reconciles all Istio-related components in order to perform a control plane upgrade.
 
@@ -169,9 +169,9 @@ $ INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jso
 $ open http://$INGRESS_HOST/productpage
 ```
 
-#### Install Istio 1.1.13
+#### Install Istio 1.1.14
 
-To install Istio 1.1.13, first we need to check out the `release-1.1` branch of our operator (this branch supports the Istio 1.1.x versions):
+To install Istio 1.1.14, first we need to check out the `release-1.1` branch of our operator (this branch supports the Istio 1.1.x versions):
 ```bash
 $ git clone git@github.com:banzaicloud/istio-operator.git
 $ git checkout release-1.1
@@ -203,7 +203,7 @@ $ helm upgrade istio-operator --install --namespace=istio-system --set-string op
 
 > If you've installed Istio 1.0.7 or earlier with the Istio operator, and if you check the logs of the operator pod at this point, you will see the following error message: `intended Istio version is unsupported by this version of the operator`. We need to update the Istio Custom Resource with Istio 1.1's components for the operator to be reconciled with the Istio control plane.
 
-To deploy Istio 1.1.13 with its default configuration options, use the following command:
+To deploy Istio 1.1.14 with its default configuration options, use the following command:
 
 ```bash
 $ kubectl apply -n istio-system -f config/samples/istio_v1beta1_istio.yaml
@@ -225,7 +225,7 @@ istio-sidecar-injector-66cd99d8c8-bp4j7   1/1       Running   0          7m
 istio-telemetry-7b667c5fbb-2lfdc          2/2       Running   0          7m
 ```
 
-The `Istio` Custom Resource is showing `Available` in its status field, and the Istio components are now using `1.1.13` images:
+The `Istio` Custom Resource is showing `Available` in its status field, and the Istio components are now using `1.1.14` images:
 
 ```bash
 $ kubectl describe istio -n istio-system istio
@@ -247,14 +247,14 @@ Spec:
   Auto Injection Namespaces:
     default
   Citadel:
-    Image:                         docker.io/istio/citadel:1.1.13
+    Image:                         docker.io/istio/citadel:1.1.14
     Replica Count:                 1
   Control Plane Security Enabled:  false
   Default Pod Disruption Budget:
     Enabled:          true
   Exclude IP Ranges:
   Galley:
-    Image:          docker.io/istio/galley:1.1.13
+    Image:          docker.io/istio/galley:1.1.14
     Replica Count:  1
   Gateways:
     Egress:
@@ -275,44 +275,44 @@ Spec:
       Enabled:        false
   Include IP Ranges:  *
   Mixer:
-    Image:          docker.io/istio/mixer:1.1.13
+    Image:          docker.io/istio/mixer:1.1.14
     Max Replicas:   5
     Min Replicas:   1
     Replica Count:  1
   Mtls:             false
   Node Agent:
     Enabled:  false
-    Image:    docker.io/istio/node-agent-k8s:1.1.13
+    Image:    docker.io/istio/node-agent-k8s:1.1.14
   Outbound Traffic Policy:
     Mode:  ALLOW_ANY
   Pilot:
-    Image:           docker.io/istio/pilot:1.1.13
+    Image:           docker.io/istio/pilot:1.1.14
     Max Replicas:    5
     Min Replicas:    1
     Replica Count:   1
     Trace Sampling:  1
   Proxy:
     Enable Core Dump:  false
-    Image:             docker.io/istio/proxyv2:1.1.13
+    Image:             docker.io/istio/proxyv2:1.1.14
   Proxy Init:
-    Image:  docker.io/istio/proxy_init:1.1.13
+    Image:  docker.io/istio/proxy_init:1.1.14
   Sds:
     Enabled:  false
   Sidecar Injector:
-    Image:                   docker.io/istio/sidecar_injector:1.1.13
+    Image:                   docker.io/istio/sidecar_injector:1.1.14
     Replica Count:           1
     Rewrite App HTTP Probe:  true
   Tracing:
     Zipkin:
       Address:  zipkin.istio-system:9411
-  Version:      1.1.13
+  Version:      1.1.14
 Status:
   Error Message:
   Status:         Available
 Events:           <none>
 ```
 
-At this point, your Istio control plane is upgraded to Istio 1.1.13 and your BookInfo application should still be available at:
+At this point, your Istio control plane is upgraded to Istio 1.1.14 and your BookInfo application should still be available at:
 ```bash
 $ open http://$INGRESS_HOST/productpage
 ```

--- a/pkg/apis/istio/v1beta1/defaults.go
+++ b/pkg/apis/istio/v1beta1/defaults.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	defaultImageHub                  = "docker.io/istio"
-	defaultImageVersion              = "1.1.13"
+	defaultImageVersion              = "1.1.14"
 	defaultPilotImage                = defaultImageHub + "/" + "pilot" + ":" + defaultImageVersion
 	defaultCitadelImage              = defaultImageHub + "/" + "citadel" + ":" + defaultImageVersion
 	defaultGalleyImage               = defaultImageHub + "/" + "galley" + ":" + defaultImageVersion


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Bump default Istio version to 1.1.14 (contains a [security fix](https://istio.io/about/notes/1.1.14/))

### Checklist

- [x] Implementation tested (on GKE)