### PR TITLE
Added support for setting trust domain (global.trustDomain equivalent)

### DIFF
--- a/config/base/crds/istio_v1beta1_istio.yaml
+++ b/config/base/crds/istio_v1beta1_istio.yaml
@@ -848,6 +848,10 @@ spec:
                       type: string
                   type: object
               type: object
+            trustDomain:
+              description: The domain serves to identify the system with SPIFFE. (default
+                "cluster.local")
+              type: string
             useMCP:
               description: Use the Mesh Control Protocol (MCP) for configuring Mixer
                 and Pilot. Requires galley.

--- a/deploy/charts/istio-operator/templates/operator-istio-1.3-crd.yaml
+++ b/deploy/charts/istio-operator/templates/operator-istio-1.3-crd.yaml
@@ -360,6 +360,9 @@ spec:
                 the scope where meshes will interact with each other, but it is not
                 required to be globally/universally unique.
               type: string
+            trustDomain:
+              description: The domain serves to identify the system with SPIFFE. (default "cluster.local")
+              type: string
             mixer:
               description: Mixer configuration options
               properties:

--- a/pkg/apis/istio/v1beta1/defaults.go
+++ b/pkg/apis/istio/v1beta1/defaults.go
@@ -460,6 +460,10 @@ func SetDefaults(config *Istio) {
 			Enabled: util.BoolPointer(false),
 		}
 	}
+
+	if config.Spec.TrustDomain == "" {
+		config.Spec.TrustDomain = "cluster.local"
+	}
 }
 
 func SetRemoteIstioDefaults(remoteconfig *RemoteIstio) {

--- a/pkg/apis/istio/v1beta1/istio_types.go
+++ b/pkg/apis/istio/v1beta1/istio_types.go
@@ -576,6 +576,9 @@ type IstioSpec struct {
 
 	networkName  string
 	meshNetworks *MeshNetworks
+
+	// The domain serves to identify the system with SPIFFE. (default "cluster.local")
+	TrustDomain string `json:"trustDomain,omitempty"`
 }
 
 type MixerlessTelemetryConfiguration struct {

--- a/pkg/resources/citadel/deployment.go
+++ b/pkg/resources/citadel/deployment.go
@@ -41,6 +41,7 @@ func (r *Reconciler) deployment() runtime.Object {
 		fmt.Sprintf("--citadel-storage-namespace=%s", r.Config.Namespace),
 		fmt.Sprintf("--custom-dns-names=istio-pilot-service-account.%[1]s:istio-pilot.%[1]s", r.Config.Namespace),
 		"--monitoring-port=15014",
+		fmt.Sprintf("--trust-domain=%s", r.Config.Spec.TrustDomain),
 	)
 
 	if r.Config.Spec.Citadel.CASecretName == "" {

--- a/pkg/resources/common/configmap.go
+++ b/pkg/resources/common/configmap.go
@@ -120,7 +120,7 @@ func (r *Reconciler) meshConfig() string {
 		"ingressClass":          "istio",
 		"ingressControllerMode": 2,
 		"sdsUdsPath":            r.Config.Spec.SDS.UdsPath,
-		"trustDomain":           "cluster.local",
+		"trustDomain":           r.Config.Spec.TrustDomain,
 		"outboundTrafficPolicy": map[string]interface{}{
 			"mode": r.Config.Spec.OutboundTrafficPolicy.Mode,
 		},

--- a/pkg/resources/gateways/deployment.go
+++ b/pkg/resources/gateways/deployment.go
@@ -94,6 +94,7 @@ func (r *Reconciler) deployment(gw string) runtime.Object {
 		"--statusPort", "15020",
 		"--controlPlaneAuthPolicy", templates.ControlPlaneAuthPolicy(r.Config.Spec.ControlPlaneSecurityEnabled),
 		"--discoveryAddress", fmt.Sprintf("istio-pilot.%s:%s", r.Config.Namespace, r.discoveryPort()),
+		"--trust-domain", r.Config.Spec.TrustDomain,
 	}
 
 	if util.PointerToBool(r.Config.Spec.Tracing.Enabled) {

--- a/pkg/resources/mixer/deployment.go
+++ b/pkg/resources/mixer/deployment.go
@@ -276,6 +276,8 @@ func (r *Reconciler) istioProxyContainer(t string) apiv1.Container {
 			templates.ControlPlaneAuthPolicy(r.Config.Spec.ControlPlaneSecurityEnabled),
 			"--domain",
 			"$(POD_NAMESPACE).svc.cluster.local",
+			"--trust-domain",
+			r.Config.Spec.TrustDomain,
 		},
 		Env: templates.IstioProxyEnv(r.Config),
 		Resources: templates.GetResourcesRequirementsOrDefault(

--- a/pkg/resources/nodeagent/daemonset.go
+++ b/pkg/resources/nodeagent/daemonset.go
@@ -73,7 +73,7 @@ func (r *Reconciler) daemonSet() runtime.Object {
 								},
 								{
 									Name:  "Trust_Domain",
-									Value: "cluster.local",
+									Value: r.Config.Spec.TrustDomain,
 								},
 								{
 									Name: "NAMESPACE",

--- a/pkg/resources/pilot/deployment.go
+++ b/pkg/resources/pilot/deployment.go
@@ -46,6 +46,8 @@ func (r *Reconciler) containerArgs() []string {
 		"cluster.local",
 		"--keepaliveMaxServerConnectionAge",
 		"30m",
+		"--trust-domain",
+		r.Config.Spec.TrustDomain,
 	}
 
 	if r.Config.Spec.ControlPlaneSecurityEnabled && !util.PointerToBool(r.Config.Spec.Pilot.Sidecar) {
@@ -185,6 +187,8 @@ func (r *Reconciler) containers() []apiv1.Container {
 				templates.ControlPlaneAuthPolicy(r.Config.Spec.ControlPlaneSecurityEnabled),
 				"--domain",
 				r.Config.Namespace + ".svc.cluster.local",
+				"--trust-domain",
+				r.Config.Spec.TrustDomain,
 			},
 			Env: templates.IstioProxyEnv(r.Config),
 			Resources: templates.GetResourcesRequirementsOrDefault(

--- a/pkg/resources/sidecarinjector/configmap.go
+++ b/pkg/resources/sidecarinjector/configmap.go
@@ -53,7 +53,7 @@ func (r *Reconciler) getValues() string {
 			"rewriteAppHTTPProbe": r.Config.Spec.SidecarInjector.RewriteAppHTTPProbe,
 		},
 		"global": map[string]interface{}{
-			"trustDomain":            "cluster.local",
+			"trustDomain":            r.Config.Spec.TrustDomain,
 			"imagePullPolicy":        r.Config.Spec.ImagePullPolicy,
 			"network":                r.Config.Spec.GetNetworkName(),
 			"podDNSSearchNamespaces": podDNSSearchNamespaces,


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #100
| License         | Apache 2.0


### What's in this PR?
Enables setting the equivalent of global.trustDomain from the Istio Helm Chart. Chose to default to "cluster.local" where that was done previously.


### Checklist

- [x] Implementation tested
- [x] User guide and development docs updated (if needed)
