### PR TITLE
remove Istio reconcile lock

### DIFF
--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -236,14 +236,6 @@ func (r *ReconcileConfig) reconcile(logger logr.Logger, config *istiov1beta1.Ist
 		return reconcile.Result{}, nil
 	}
 
-	if config.Status.Status == istiov1beta1.Reconciling {
-		logger.Info("cannot trigger reconcile while already reconciling")
-		return reconcile.Result{
-			Requeue:      true,
-			RequeueAfter: time.Duration(30) * time.Second,
-		}, nil
-	}
-
 	err := updateStatus(r.Client, config, istiov1beta1.Reconciling, "", logger)
 	if err != nil {
 		return reconcile.Result{}, errors.WithStack(err)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

This PR removes the check which kickbacks the reconciliation logic if the Istio CR status is `Reconciling`, it seems unnecessary and could cause unwanted deadlock. 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Originally it was implemented to prevent reconciliation to run multiple times at once  for the same resource, but the controller lock mechanism of the operator and kubebuilder prevents this by others means already.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
