### PR TITLE
Support Istio 1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If you are willing to kickstart your Istio experience using Pipeline, check out 
 
 ## Installation
 
-The operator (`release-1.3` branch) installs the 1.3.1 version of Istio, and can run on Minikube v1.1.1+ and Kubernetes 1.13.0+.
+The operator (`release-1.3` branch) installs the 1.3.2 version of Istio, and can run on Minikube v1.1.1+ and Kubernetes 1.13.0+.
 
 As a pre-requisite it needs a Kubernetes cluster (you can create one using [Pipeline](https://github.com/banzaicloud/pipeline)).
 

--- a/config/samples/istio_v1beta1_istio.yaml
+++ b/config/samples/istio_v1beta1_istio.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   mtls: false
   includeIPRanges: "*"
   excludeIPRanges: ""
@@ -19,7 +19,7 @@ spec:
     enabled: false
   pilot:
     enabled: true
-    image: "docker.io/istio/pilot:1.3.1"
+    image: "docker.io/istio/pilot:1.3.2"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
@@ -30,10 +30,10 @@ spec:
         memory: 2048Mi
   citadel:
     enabled: true
-    image: "docker.io/istio/citadel:1.3.1"
+    image: "docker.io/istio/citadel:1.3.2"
   galley:
     enabled: true
-    image: "docker.io/istio/galley:1.3.1"
+    image: "docker.io/istio/galley:1.3.2"
     replicaCount: 1
   gateways:
     enabled: true
@@ -96,13 +96,13 @@ spec:
       enabled: false
   mixer:
     enabled: true
-    image: "docker.io/istio/mixer:1.3.1"
+    image: "docker.io/istio/mixer:1.3.2"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
   sidecarInjector:
     enabled: true
-    image: "docker.io/istio/sidecar_injector:1.3.1"
+    image: "docker.io/istio/sidecar_injector:1.3.2"
     replicaCount: 1
     rewriteAppHTTPProbe: true
     autoInjectionPolicyEnabled: true
@@ -116,9 +116,9 @@ spec:
           memory: 50Mi
   nodeAgent:
     enabled: false
-    image: "docker.io/istio/node-agent-k8s:1.3.1"
+    image: "docker.io/istio/node-agent-k8s:1.3.2"
   proxy:
-    image: "docker.io/istio/proxyv2:1.3.1"
+    image: "docker.io/istio/proxyv2:1.3.2"
     accessLogFile: "/dev/stdout"
     accessLogFormat: ""
     accessLogEncoding: "TEXT"
@@ -131,7 +131,7 @@ spec:
         cpu: 2000m
         memory: 1024Mi
   proxyInit:
-    image: "docker.io/istio/proxy_init:1.3.1"
+    image: "docker.io/istio/proxy_init:1.3.2"
   defaultPodDisruptionBudget:
     enabled: true
   outboundTrafficPolicy:

--- a/config/samples/istio_v1beta1_istio_cni.yaml
+++ b/config/samples/istio_v1beta1_istio_cni.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   mtls: false
   autoInjectionNamespaces:
   - "default"

--- a/config/samples/istio_v1beta1_istio_cni_gke.yaml
+++ b/config/samples/istio_v1beta1_istio_cni_gke.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   mtls: false
   autoInjectionNamespaces:
   - "default"

--- a/config/samples/istio_v1beta1_istio_meshexpansion.yaml
+++ b/config/samples/istio_v1beta1_istio_meshexpansion.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   autoInjectionNamespaces:
   - "default"
   useMCP: true

--- a/config/samples/istio_v1beta1_istio_minimal.yaml
+++ b/config/samples/istio_v1beta1_istio_minimal.yaml
@@ -7,7 +7,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   mtls: false
   autoInjectionNamespaces:
   - "default"

--- a/config/samples/istio_v1beta1_istio_multimesh.yaml
+++ b/config/samples/istio_v1beta1_istio_multimesh.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: multimesh
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   autoInjectionNamespaces:
   - "default"
   useMCP: true

--- a/config/samples/istio_v1beta1_istio_nodeaffinities.yaml
+++ b/config/samples/istio_v1beta1_istio_nodeaffinities.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   mtls: false
   includeIPRanges: "*"
   excludeIPRanges: ""
@@ -16,7 +16,7 @@ spec:
     enabled: false
   pilot:
     enabled: true
-    image: "docker.io/istio/pilot:1.3.1"
+    image: "docker.io/istio/pilot:1.3.2"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
@@ -30,10 +30,10 @@ spec:
       tolerationSeconds: 6000
   citadel:
     enabled: true
-    image: "docker.io/istio/citadel:1.3.1"
+    image: "docker.io/istio/citadel:1.3.2"
   galley:
     enabled: true
-    image: "docker.io/istio/galley:1.3.1"
+    image: "docker.io/istio/galley:1.3.2"
     replicaCount: 1
   gateways:
     enabled: true
@@ -89,24 +89,24 @@ spec:
       enabled: false
   mixer:
     enabled: true
-    image: "docker.io/istio/mixer:1.3.1"
+    image: "docker.io/istio/mixer:1.3.2"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
   sidecarInjector:
     enabled: true
-    image: "docker.io/istio/sidecar_injector:1.3.1"
+    image: "docker.io/istio/sidecar_injector:1.3.2"
     replicaCount: 1
     rewriteAppHTTPProbe: true
     autoInjectionPolicyEnabled: true
   nodeAgent:
     enabled: false
-    image: "docker.io/istio/node-agent-k8s:1.3.1"
+    image: "docker.io/istio/node-agent-k8s:1.3.2"
   proxy:
-    image: "docker.io/istio/proxyv2:1.3.1"
+    image: "docker.io/istio/proxyv2:1.3.2"
     enableCoreDump: false
   proxyInit:
-    image: "docker.io/istio/proxy_init:1.3.1"
+    image: "docker.io/istio/proxy_init:1.3.2"
   defaultPodDisruptionBudget:
     enabled: true
   outboundTrafficPolicy:

--- a/config/samples/istio_v1beta1_istio_sds_auth.yaml
+++ b/config/samples/istio_v1beta1_istio_sds_auth.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: istio-sample
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   mtls: true
   autoInjectionNamespaces:
   - "default"
@@ -19,7 +19,7 @@ spec:
       enabled: true
       sds:
         enabled: true
-        image: "docker.io/istio/node-agent-k8s:1.3.1"
+        image: "docker.io/istio/node-agent-k8s:1.3.2"
         resources:
           requests:
             cpu: 100m
@@ -29,4 +29,4 @@ spec:
             memory: 1024Mi
   nodeAgent:
     enabled: true
-    image: "docker.io/istio/node-agent-k8s:1.3.1"
+    image: "docker.io/istio/node-agent-k8s:1.3.2"

--- a/deploy/charts/istio-operator/Chart.yaml
+++ b/deploy/charts/istio-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: istio-operator
-version: 0.0.20
+version: 0.0.21
 description: istio-operator manages Istio deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/istio-operator
-appVersion: 0.3.0
+appVersion: 0.3.2
 icon: https://istio.io/img/istio-logo-social-blue-background.svg

--- a/deploy/charts/istio-operator/README.md
+++ b/deploy/charts/istio-operator/README.md
@@ -32,7 +32,7 @@ The following table lists the configurable parameters of the Banzaicloud Istio O
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | Operator container image repository | `banzaicloud/istio-operator`
-`operator.image.tag` | Operator container image tag | `0.3.0`
+`operator.image.tag` | Operator container image tag | `0.3.2`
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `operator.resources` | CPU/Memory resource requests/limits (YAML) | Memory: `128Mi/256Mi`, CPU: `100m/200m`
 `istioVersion` | Supported Istio version | `1.3`

--- a/deploy/charts/istio-operator/values.yaml
+++ b/deploy/charts/istio-operator/values.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: banzaicloud/istio-operator
-    tag: 0.3.0
+    tag: 0.3.2
     pullPolicy: IfNotPresent
   resources:
     limits:

--- a/docs/federation/gateway/samples/istio-multicluster-cr.yaml
+++ b/docs/federation/gateway/samples/istio-multicluster-cr.yaml
@@ -3,7 +3,7 @@ kind: Istio
 metadata:
   name: gateway-multicluster
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   autoInjectionNamespaces:
   - "default"
   mtls: true

--- a/docs/federation/multimesh/istio-multimesh-cr.yaml
+++ b/docs/federation/multimesh/istio-multimesh-cr.yaml
@@ -5,7 +5,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: multimesh
 spec:
-  version: "1.3.1"
+  version: "1.3.2"
   autoInjectionNamespaces:
   - "default"
   useMCP: true

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -147,10 +147,10 @@ Alternatively, you can deploy the operator using a [Helm chart](https://github.c
 
 ```bash
 $ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
-$ helm upgrade istio-operator --install --namespace=istio-system --set-string operator.image.tag=0.3.0 banzaicloud-stable/istio-operator
+$ helm upgrade istio-operator --install --namespace=istio-system --set-string operator.image.tag=0.3.2 banzaicloud-stable/istio-operator
 ```
 
-*Note: As of now, the `0.3.0` tag is the latest version of our operator to support Istio versions 1.3.x
+*Note: As of now, the `0.3.2` tag is the latest version of our operator to support Istio versions 1.3.x
 
 **Apply the new Custom Resource**
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -4,10 +4,10 @@ The steps are listed in this doc to perform an Istio version upgrade with the op
 
 ## Istio Control Plane Upgrade
 
-Let us suppose that we have a [Kubernetes](https://kubernetes.io/) cluster with Istio 1.2.5, and we would like to upgrade our Istio components to Istio version 1.3.1. Here are the steps we need to perform to accomplish this with the operator:
+Let us suppose that we have a [Kubernetes](https://kubernetes.io/) cluster with Istio 1.2.5, and we would like to upgrade our Istio components to Istio version 1.3.2. Here are the steps we need to perform to accomplish this with the operator:
 
 1. Deploy a version of the operator which supports Istio 1.3.x
-2. Apply a [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) using Istio 1.3.1 components
+2. Apply a [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) using Istio 1.3.2 components
 
 What happens is that once the operator discerns that the Custom Resource it's watching has changed, it reconciles all Istio-related components in order to perform a control plane upgrade.
 
@@ -120,9 +120,9 @@ $ INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jso
 $ open http://$INGRESS_HOST/productpage
 ```
 
-#### Install Istio 1.3.1
+#### Install Istio 1.3.2
 
-To install Istio 1.3.1, first we need to check out the `release-1.3` branch of our operator (this branch supports the Istio 1.3.x versions):
+To install Istio 1.3.2, first we need to check out the `release-1.3` branch of our operator (this branch supports the Istio 1.3.x versions):
 
 ```bash
 $ git clone git@github.com:banzaicloud/istio-operator.git
@@ -156,7 +156,7 @@ $ helm upgrade istio-operator --install --namespace=istio-system --set-string op
 
 > If you've installed Istio 1.1.11 or earlier with the Istio operator, and if you check the logs of the operator pod at this point, you will see the following error message: `intended Istio version is unsupported by this version of the operator`. We need to update the Istio Custom Resource with Istio 1.3's components for the operator to be reconciled with the Istio control plane.
 
-To deploy Istio 1.3.1 with its default configuration options, use the following command:
+To deploy Istio 1.3.2 with its default configuration options, use the following command:
 
 ```bash
 $ kubectl apply -n istio-system -f config/samples/istio_v1beta1_istio.yaml
@@ -178,27 +178,27 @@ istio-sidecar-injector-66cd99d8c8-bp4j7   1/1       Running   0          7m
 istio-telemetry-7b667c5fbb-2lfdc          2/2       Running   0          7m
 ```
 
-The `Istio` Custom Resource is showing `Available` in its status field, and the Istio components are now using `1.3.1` images:
+The `Istio` Custom Resource is showing `Available` in its status field, and the Istio components are now using `1.3.2` images:
 
 ```bash
 $ kubectl describe istio -n istio-system istio | grep Image:
-    Image:                         docker.io/istio/citadel:1.3.1
-    Image:          docker.io/istio/galley:1.3.1
-    Image:    docker.io/istio/node-agent-k8s:1.3.1
-        Image:    docker.io/istio/node-agent-k8s:1.3.1
+    Image:                         docker.io/istio/citadel:1.3.2
+    Image:          docker.io/istio/galley:1.3.2
+    Image:    docker.io/istio/node-agent-k8s:1.3.2
+        Image:    docker.io/istio/node-agent-k8s:1.3.2
     Image:          coredns/coredns:1.1.2
     Plugin Image:   docker.io/istio/coredns-plugin:0.2-istio-1.1
-    Image:          docker.io/istio/mixer:1.3.1
-    Image:    docker.io/istio/node-agent-k8s:1.3.1
-    Image:          docker.io/istio/pilot:1.3.1
-    Image:             docker.io/istio/proxyv2:1.3.1
-    Image:  docker.io/istio/proxy_init:1.3.1
-    Image:                          docker.io/istio/sidecar_injector:1.3.1
-      Image:                 docker.io/istio/install-cni:1.3.1
+    Image:          docker.io/istio/mixer:1.3.2
+    Image:    docker.io/istio/node-agent-k8s:1.3.2
+    Image:          docker.io/istio/pilot:1.3.2
+    Image:             docker.io/istio/proxyv2:1.3.2
+    Image:  docker.io/istio/proxy_init:1.3.2
+    Image:                          docker.io/istio/sidecar_injector:1.3.2
+      Image:                 docker.io/istio/install-cni:1.3.2
 
 ```
 
-At this point, your Istio control plane is upgraded to Istio 1.3.1 and your BookInfo application should still be available at:
+At this point, your Istio control plane is upgraded to Istio 1.3.2 and your BookInfo application should still be available at:
 ```bash
 $ open http://$INGRESS_HOST/productpage
 ```

--- a/pkg/apis/istio/v1beta1/defaults.go
+++ b/pkg/apis/istio/v1beta1/defaults.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	defaultImageHub                  = "docker.io/istio"
-	defaultImageVersion              = "1.3.1"
+	defaultImageVersion              = "1.3.2"
 	defaultPilotImage                = defaultImageHub + "/" + "pilot" + ":" + defaultImageVersion
 	defaultCitadelImage              = defaultImageHub + "/" + "citadel" + ":" + defaultImageVersion
 	defaultGalleyImage               = defaultImageHub + "/" + "galley" + ":" + defaultImageVersion

--- a/pkg/apis/istio/v1beta1/istio_types_test.go
+++ b/pkg/apis/istio/v1beta1/istio_types_test.go
@@ -36,7 +36,7 @@ func TestStorageIstio(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: IstioSpec{
-			Version: "1.3.1",
+			Version: "1.3.2",
 		},
 	}
 	g := gomega.NewGomegaWithT(t)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Bump default Istio version to 1.3.2
- Bump image and chart versions (image tag 0.3.1 was already used)

### Checklist

- [x] Implementation tested (on PKE)