### PR TITLE
use auto injection namespaces at remotes if not explicitly overridden

### DIFF
--- a/pkg/remoteclusters/reconcile_config.go
+++ b/pkg/remoteclusters/reconcile_config.go
@@ -46,7 +46,9 @@ func (c *Cluster) reconcileConfig(remoteConfig *istiov1beta1.RemoteIstio, istio 
 	}
 
 	istioConfig.Spec = istio.Spec
-	istioConfig.Spec.AutoInjectionNamespaces = remoteConfig.Spec.AutoInjectionNamespaces
+	if len(remoteConfig.Spec.AutoInjectionNamespaces) > 0 {
+		istioConfig.Spec.AutoInjectionNamespaces = remoteConfig.Spec.AutoInjectionNamespaces
+	}
 	istioConfig.Spec.SidecarInjector.ReplicaCount = remoteConfig.Spec.SidecarInjector.ReplicaCount
 	istioConfig.Spec.Proxy.Privileged = remoteConfig.Spec.Proxy.Privileged
 	istioConfig.Spec.Citadel.NodeSelector = remoteConfig.Spec.Citadel.NodeSelector


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Use auto injection namespaces setting for remote clusters from Istio CR unless directly specified in a RemoteIstio CR.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In a single multi-cluster setup a particular namespace is basically treated the same in every cluster, so the auto injection namespace labels must be set accordingly, unless the user explicitly overrides this behaviour in a RemoteIstio CR.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
