### PR TITLE
Only create meshexpansion-dr-pilot destination rule when meshexpansion is enabled as well

### DIFF
--- a/deploy/charts/istio-operator/Chart.yaml
+++ b/deploy/charts/istio-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: istio-operator
-version: 0.0.23
+version: 0.0.24
 description: istio-operator manages Istio deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/istio-operator
-appVersion: 0.3.4
+appVersion: 0.3.5
 icon: https://istio.io/img/istio-logo-social-blue-background.svg

--- a/deploy/charts/istio-operator/README.md
+++ b/deploy/charts/istio-operator/README.md
@@ -32,7 +32,7 @@ The following table lists the configurable parameters of the Banzaicloud Istio O
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | Operator container image repository | `banzaicloud/istio-operator`
-`operator.image.tag` | Operator container image tag | `0.3.4`
+`operator.image.tag` | Operator container image tag | `0.3.5`
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `operator.resources` | CPU/Memory resource requests/limits (YAML) | Memory: `128Mi/256Mi`, CPU: `100m/200m`
 `istioVersion` | Supported Istio version | `1.3`

--- a/deploy/charts/istio-operator/values.yaml
+++ b/deploy/charts/istio-operator/values.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: banzaicloud/istio-operator
-    tag: 0.3.4
+    tag: 0.3.5
     pullPolicy: IfNotPresent
   resources:
     limits:

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -147,10 +147,10 @@ Alternatively, you can deploy the operator using a [Helm chart](https://github.c
 
 ```bash
 $ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
-$ helm upgrade istio-operator --install --namespace=istio-system --set-string operator.image.tag=0.3.4 banzaicloud-stable/istio-operator
+$ helm upgrade istio-operator --install --namespace=istio-system --set-string operator.image.tag=0.3.5 banzaicloud-stable/istio-operator
 ```
 
-*Note: As of now, the `0.3.4` tag is the latest version of our operator to support Istio versions 1.3.x
+*Note: As of now, the `0.3.5` tag is the latest version of our operator to support Istio versions 1.3.x
 
 **Apply the new Custom Resource**
 

--- a/pkg/resources/pilot/pilot.go
+++ b/pkg/resources/pilot/pilot.go
@@ -98,21 +98,19 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	}
 
 	var meshExpansionDesiredState k8sutil.DesiredState
+	var meshExpansionDestinationRuleDesiredState k8sutil.DesiredState
 	if util.PointerToBool(r.Config.Spec.MeshExpansion) {
 		meshExpansionDesiredState = k8sutil.DesiredStatePresent
+		if r.Config.Spec.ControlPlaneSecurityEnabled {
+			meshExpansionDestinationRuleDesiredState = k8sutil.DesiredStatePresent
+		}
 	} else {
 		meshExpansionDesiredState = k8sutil.DesiredStateAbsent
-	}
-
-	var controlPlaneSecurityDesiredState k8sutil.DesiredState
-	if r.Config.Spec.ControlPlaneSecurityEnabled {
-		controlPlaneSecurityDesiredState = k8sutil.DesiredStatePresent
-	} else {
-		controlPlaneSecurityDesiredState = k8sutil.DesiredStateAbsent
+		meshExpansionDestinationRuleDesiredState = k8sutil.DesiredStateAbsent
 	}
 
 	for _, dr := range []resources.DynamicResourceWithDesiredState{
-		{DynamicResource: r.meshExpansionDestinationRule, DesiredState: controlPlaneSecurityDesiredState},
+		{DynamicResource: r.meshExpansionDestinationRule, DesiredState: meshExpansionDestinationRuleDesiredState},
 		{DynamicResource: r.meshExpansionVirtualService, DesiredState: meshExpansionDesiredState},
 	} {
 		o := dr.DynamicResource()


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Only create meshexpansion-dr-pilot destination rule when meshexpansion is enabled as well
- Bump image and chart versions

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Backyards validations caught the following error:
<img width="1920" alt="Screenshot 2019-11-04 at 14 48 06" src="https://user-images.githubusercontent.com/11650801/68125590-35494800-ff12-11e9-9def-0a656f67da38.png">

This destination rule resource was created in a single-cluster setup in which case it should have not been created. See: https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/charts/pilot/templates/meshexpansion.yaml#L1

`ControlPlaneSecurityEnabled` set to true is not enough to create this resource, `MeshExpansion` should be set to true as well, hence the fix.
