### PR TITLE
Bump manage pod resource limit

### DIFF
--- a/config/base/manager/manager.yaml
+++ b/config/base/manager/manager.yaml
@@ -46,8 +46,8 @@ spec:
                 fieldPath: metadata.namespace
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 1000m
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes|
| New feature?    | no|
| API breaks?     | no|
| Deprecations?   | no
| Related tickets | fixes #328 |
| License         | Apache 2.0


### What's in this PR?

- This PR bumps the default `manager` pod resource limits.

### Why?

My istio operator would never become ready on our large clusters and would be stuck in `Reconciling` after being installed. This is due to the resource limits on the manager pod being too low and it not having enough RAM to index the initial cluster contents.

I worked with @Laci21 and also discussed / debugged the issue with him on Slack [here](https://community-banzaicloud.slack.com/archives/CGKQF5HUP/p1574182196040500)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] Implementation tested

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] Note: I've just bumped the default limits for this pod by a factor of 10 and it has worked without issue, if you find a different number more acceptable feel free to modify.
