### PR TITLE
Enhancements

### DIFF
--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
 - base/crds/istio_v1beta1_istio.yaml
 - base/crds/istio_v1beta1_remoteistio.yaml
+- base/crds/istio_v1beta1_meshgateway.yaml
 - base/manager/namespace.yaml

--- a/config/samples/istio_v1beta1_meshgateway.yaml
+++ b/config/samples/istio_v1beta1_meshgateway.yaml
@@ -20,10 +20,8 @@ spec:
     - port: 80
       targetPort: 80
       name: http2
-      nodePort: 31380
     - port: 443
       name: https
-      nodePort: 31390
     - port: 15443
       targetPort: 15443
       name: tls

--- a/pkg/controller/meshgateway/meshgateway_controller.go
+++ b/pkg/controller/meshgateway/meshgateway_controller.go
@@ -72,7 +72,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to MeshGateway
-	err = c.Watch(&source.Kind{Type: &istiov1beta1.MeshGateway{}}, &handler.EnqueueRequestForObject{}, k8sutil.GetWatchPredicateForMeshGateway())
+	err = c.Watch(&source.Kind{Type: &istiov1beta1.MeshGateway{TypeMeta: metav1.TypeMeta{Kind: "MeshGateway", APIVersion: "istio.banzaicloud.io/v1beta1"}}}, &handler.EnqueueRequestForObject{}, k8sutil.GetWatchPredicateForMeshGateway())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Add mesh gateway CRD creation to Kustomize
- Add TypeMeta to mesh gateway manager
- Remove nodeports from mesh gateway example config to avoid port collisions

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

- So that it works with Kustomize as well. `make deploy` also uses Kustomize, the operator fails to start without this fix.
- Without the commit the operator starts like this: `{“level”:“info”,“ts”:1575981188.5288014,“logger”:“kubebuilder.controller”,“msg”:“Starting EventSource”,“controller”:“meshgateway-controller”,“source”:“kind source: /, Kind=“}`
With the commit: `{“level”:“info”,“ts”:1575982473.2791457,“logger”:“kubebuilder.controller”,“msg”:“Starting EventSource”,“controller”:“meshgateway-controller”,“source”:“kind source: istio.banzaicloud.io/v1beta1, Kind=MeshGateway”}`
- When both `config/samples/istio_v1beta1_istio.yaml` and `config/samples/istio_v1beta1_meshgateway.yaml` are applied, the second one fails with nodeport collisions.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested

