### PR TITLE
Abort reconciliation when multiple Istio CRs are found

### DIFF
--- a/pkg/apis/istio/v1beta1/common_types.go
+++ b/pkg/apis/istio/v1beta1/common_types.go
@@ -24,4 +24,5 @@ const (
 	Reconciling     ConfigState = "Reconciling"
 	Available       ConfigState = "Available"
 	Unmanaged       ConfigState = "Unmanaged"
+	Conflicting     ConfigState = "Conflicting"
 )

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -419,7 +419,6 @@ func (r *ReconcileConfig) checkIstioCount(ctx context.Context, logger logr.Logge
 			RequeueAfter: 30 * time.Second,
 		}, nil
 	}
-	logger.Info("Got Istio CR count", "count", count)
 
 	if count > 1 {
 		err := errors.New("multiple Istio CRs found")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
When multiple Istio CRs are found, istio-operator aborts reconciliation.


### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)
