### PR TITLE
More POSIX compatible Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ run: generate fmt vet
 
 # Install kustomize
 install-kustomize:
-	@ if ! which bin/kustomize &>/dev/null; then\
+	@ if ! which bin/kustomize >/dev/null 2>&1; then\
 		scripts/install_kustomize.sh;\
 	fi
 
 # Install kubebuilder
 install-kubebuilder:
-	@ if ! which bin/kubebuilder/bin/kubebuilder &>/dev/null; then\
+	@ if ! which bin/kubebuilder/bin/kubebuilder >/dev/null 2>&1; then\
 		scripts/install_kubebuilder.sh;\
 	fi
 


### PR DESCRIPTION
This fix makes the recipes work as intended in POSIX compatible shells

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0

### What's in this PR?
Makefile fix for systems with POSIX compatible `/bin/sh`

### Why?
Without this fix, running `make` keeps downloading kubebuilder.
