### PR TITLE
Fix changing MeshPolicy to disabled to adjust to CRD schema validation

### DIFF
--- a/pkg/resources/citadel/mtls.go
+++ b/pkg/resources/citadel/mtls.go
@@ -23,18 +23,18 @@ import (
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
 )
 
-// peers returns a map slice to configure the default MeshPolicy
-func (r *Reconciler) peers() []map[string]interface{} {
+// spec returns a map to configure the default MeshPolicy
+func (r *Reconciler) spec() map[string]interface{} {
 	if r.Config.Spec.MeshPolicy.MTLSMode == v1beta1.DISABLED {
-		return []map[string]interface{}{
-			{},
-		}
+		return map[string]interface{}{}
 	}
 
-	return []map[string]interface{}{
-		{
-			"mtls": map[string]interface{}{
-				"mode": r.Config.Spec.MeshPolicy.MTLSMode,
+	return map[string]interface{}{
+		"peers": []map[string]interface{}{
+			{
+				"mtls": map[string]interface{}{
+					"mode": r.Config.Spec.MeshPolicy.MTLSMode,
+				},
 			},
 		},
 	}
@@ -53,10 +53,8 @@ func (r *Reconciler) meshPolicy() *k8sutil.DynamicObject {
 		Kind:   "MeshPolicy",
 		Name:   "default",
 		Labels: citadelLabels,
-		Spec: map[string]interface{}{
-			"peers": r.peers(),
-		},
-		Owner: r.Config,
+		Spec:   r.spec(),
+		Owner:  r.Config,
 	}
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

When CRD schema validations are used the following error happens when setting the MeshPolicy to `DISABLED`:
```
"spec\":map[string]interface {}{\"peers\":[]interface {}{map[string]interface {}{}}}}: validation failure list:\n\"spec.peers\" must validate one and only one schema (oneOf). Found none valid\nspec.peers.mtls in body is 
required\nupdating resource failed
```

This is because the following was set in the MeshPolicy:
```
spec:
  peers:
  - {}
```

With this fix this will be set:
```
spec: {}
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested

