### PR TITLE
Support additional env variables in MeshGateway resource

### DIFF
--- a/config/base/crds/istio_v1beta1_istio.yaml
+++ b/config/base/crds/istio_v1beta1_istio.yaml
@@ -214,6 +214,12 @@ spec:
               properties:
                 egress:
                   properties:
+                    additionalEnvVars:
+                      description: If present will be appended to the environment
+                        variables of the container
+                      items:
+                        type: object
+                      type: array
                     affinity:
                       type: object
                     applicationPorts:
@@ -273,6 +279,12 @@ spec:
                   type: boolean
                 ingress:
                   properties:
+                    additionalEnvVars:
+                      description: If present will be appended to the environment
+                        variables of the container
+                      items:
+                        type: object
+                      type: array
                     affinity:
                       type: object
                     applicationPorts:

--- a/config/base/crds/istio_v1beta1_meshgateway.yaml
+++ b/config/base/crds/istio_v1beta1_meshgateway.yaml
@@ -56,6 +56,12 @@ spec:
           type: object
         spec:
           properties:
+            additionalEnvVars:
+              description: If present will be appended to the environment variables
+                of the container
+              items:
+                type: object
+              type: array
             affinity:
               type: object
             applicationPorts:

--- a/config/samples/istio_v1beta1_meshgateway.yaml
+++ b/config/samples/istio_v1beta1_meshgateway.yaml
@@ -25,7 +25,13 @@ spec:
     - port: 15443
       targetPort: 15443
       name: tls
-  additionalEnvVars: []
+#   additionalEnvVars:
+#   - name: ADDITIONAL_VARIABLE
+#     value: "value"
+#   - name: META_POD_NAME
+#     valueFrom:
+#       fieldRef:
+#         fieldPath: metadata.name
   applicationPorts: ""
   resources:
     requests:

--- a/config/samples/istio_v1beta1_meshgateway.yaml
+++ b/config/samples/istio_v1beta1_meshgateway.yaml
@@ -25,6 +25,7 @@ spec:
     - port: 15443
       targetPort: 15443
       name: tls
+  additionalEnvVars: []
   applicationPorts: ""
   resources:
     requests:

--- a/pkg/apis/istio/v1beta1/meshgateway_types.go
+++ b/pkg/apis/istio/v1beta1/meshgateway_types.go
@@ -47,6 +47,8 @@ type MeshGatewayConfiguration struct {
 	SDS                  GatewaySDSConfiguration `json:"sds,omitempty"`
 	ApplicationPorts     string                  `json:"applicationPorts,omitempty"`
 	RequestedNetworkView string                  `json:"requestedNetworkView,omitempty"`
+	// If present will be appended to the environment variables of the container
+	AdditionalEnvVars []corev1.EnvVar `json:"additionalEnvVars,omitempty"`
 }
 
 // MeshGatewayStatus defines the observed state of MeshGateway

--- a/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
@@ -890,6 +890,13 @@ func (in *MeshGatewayConfiguration) DeepCopyInto(out *MeshGatewayConfiguration) 
 		}
 	}
 	in.SDS.DeepCopyInto(&out.SDS)
+	if in.AdditionalEnvVars != nil {
+		in, out := &in.AdditionalEnvVars, &out.AdditionalEnvVars
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/resources/gateways/deployment.go
+++ b/pkg/resources/gateways/deployment.go
@@ -399,6 +399,8 @@ func (r *Reconciler) envVars() []apiv1.EnvVar {
 		}
 	}
 
+	envVars = k8sutil.MergeEnvVars(envVars, r.gw.Spec.AdditionalEnvVars)
+
 	return envVars
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     |  no|yes
| Deprecations?   | no|yes
| Related tickets | #294  
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add support for additional env variables to `MeshGateway` resource.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Currently is not possible to set additional environment variables, but it is a necessity for advanced configuration.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Variables are merged by name,  new variables are simply appended.
This is an advanced feature which can lead to misconfiguration if not used properly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
