### PR TITLE
Fix helm chart template names

### DIFF
--- a/deploy/charts/istio-operator/templates/operator-rbac.yaml
+++ b/deploy/charts/istio-operator/templates/operator-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "istio-operator.fullname" . }}-operator
+  name: {{ include "istio-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "istio-operator.name" . }}
@@ -15,7 +15,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "istio-operator.fullname" . }}-operator
+  name: {{ include "istio-operator.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "istio-operator.name" . }}
     helm.sh/chart: {{ include "istio-operator.chart" . }}
@@ -339,7 +339,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "istio-operator.fullname" . }}-operator
+  name: {{ include "istio-operator.fullname" . }}
   labels:
     app.kubernetes.io/name: {{ include "istio-operator.name" . }}
     helm.sh/chart: {{ include "istio-operator.chart" . }}
@@ -350,9 +350,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "istio-operator.fullname" . }}-operator
+  name: {{ include "istio-operator.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "istio-operator.fullname" . }}-operator
+  name: {{ include "istio-operator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy/charts/istio-operator/templates/operator-service.yaml
+++ b/deploy/charts/istio-operator/templates/operator-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ include "istio-operator.fullname" . }}-operator"
+  name: "{{ include "istio-operator.fullname" . }}"
   namespace: {{ .Release.Namespace }}
   {{- if and .Values.prometheusMetrics.enabled (not .Values.prometheusMetrics.authProxy.enabled) }}
   annotations:

--- a/deploy/charts/istio-operator/templates/operator-statefulset.yaml
+++ b/deploy/charts/istio-operator/templates/operator-statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: "{{ include "istio-operator.fullname" . }}-operator"
+  name: "{{ include "istio-operator.fullname" . }}"
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
@@ -20,7 +20,7 @@ spec:
       app.kubernetes.io/name: {{ include "istio-operator.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: operator
-  serviceName: {{ include "istio-operator.fullname" . }}-operator
+  serviceName: {{ include "istio-operator.fullname" . }}
   template:
     metadata:
       labels:
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/component: operator
     spec:
       {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ include "istio-operator.fullname" . }}-operator
+      serviceAccountName: {{ include "istio-operator.fullname" . }}
       {{- end }}
       terminationGracePeriodSeconds: 60
       containers:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #383
| License         | Apache 2.0


### What's in this PR?
Removes "-operator" in various spots in the Helm chart.

### Why?
When this Helm chart is installed, the StatefulSet, Service, and RBAC resources
have their name as 'istio-operator-operator'. This fixes that so it's just 'istio-operator'.


### Additional context
N/A


### Checklist

- [x] Implementation tested