### PR TITLE
Allow appending a suffix to resource names

### DIFF
--- a/deploy/charts/istio-operator/templates/operator-rbac.yaml
+++ b/deploy/charts/istio-operator/templates/operator-rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "istio-operator.fullname" . }}
+  name: {{ include "istio-operator.fullname" . }}{{ .Values.operatorComponentSuffix }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "istio-operator.name" . }}
@@ -15,7 +15,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "istio-operator.fullname" . }}
+  name: {{ include "istio-operator.fullname" . }}{{ .Values.operatorComponentSuffix }}
   labels:
     app.kubernetes.io/name: {{ include "istio-operator.name" . }}
     helm.sh/chart: {{ include "istio-operator.chart" . }}
@@ -339,7 +339,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "istio-operator.fullname" . }}
+  name: {{ include "istio-operator.fullname" . }}{{ .Values.operatorComponentSuffix }}
   labels:
     app.kubernetes.io/name: {{ include "istio-operator.name" . }}
     helm.sh/chart: {{ include "istio-operator.chart" . }}
@@ -350,9 +350,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "istio-operator.fullname" . }}
+  name: {{ include "istio-operator.fullname" . }}{{ .Values.operatorComponentSuffix }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "istio-operator.fullname" . }}
+  name: {{ include "istio-operator.fullname" . }}{{ .Values.operatorComponentSuffix }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy/charts/istio-operator/templates/operator-service.yaml
+++ b/deploy/charts/istio-operator/templates/operator-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ include "istio-operator.fullname" . }}"
+  name: "{{ include "istio-operator.fullname" . }}{{ .Values.operatorComponentSuffix }}"
   namespace: {{ .Release.Namespace }}
   {{- if and .Values.prometheusMetrics.enabled (not .Values.prometheusMetrics.authProxy.enabled) }}
   annotations:

--- a/deploy/charts/istio-operator/templates/operator-statefulset.yaml
+++ b/deploy/charts/istio-operator/templates/operator-statefulset.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: "{{ include "istio-operator.fullname" . }}"
+  name: "{{ include "istio-operator.fullname" . }}{{ .Values.operatorComponentSuffix }}"
   namespace: {{ .Release.Namespace }}
   labels:
     control-plane: controller-manager
@@ -20,7 +20,7 @@ spec:
       app.kubernetes.io/name: {{ include "istio-operator.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: operator
-  serviceName: {{ include "istio-operator.fullname" . }}
+  serviceName: {{ include "istio-operator.fullname" . }}{{ .Values.operatorComponentSuffix }}
   template:
     metadata:
       labels:
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/component: operator
     spec:
       {{- if .Values.rbac.enabled }}
-      serviceAccountName: {{ include "istio-operator.fullname" . }}
+      serviceAccountName: {{ include "istio-operator.fullname" . }}{{ .Values.operatorComponentSuffix }}
       {{- end }}
       terminationGracePeriodSeconds: 60
       containers:

--- a/deploy/charts/istio-operator/values.yaml
+++ b/deploy/charts/istio-operator/values.yaml
@@ -43,3 +43,5 @@ fullnameOverride: ""
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+operatorComponentSuffix: ""


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
Other tools might depend on the original naming of the k8s resources, so this PR makes it possible to use the old naming (istio-operator-operator).

