### PR TITLE
Update golang and golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.11
+      - image: circleci/golang:1.14
 
     working_directory: /go/src/github.com/banzaicloud/istio-operator
     steps:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ RELEASE_MSG ?= "operator release"
 REL_TAG = $(shell ./scripts/increment_version.sh -${RELEASE_TYPE} ${TAG})
 
 DEP_VERSION = 0.5.1
-GOLANGCI_VERSION = 1.15.0
+GOLANGCI_VERSION = 1.23.8
 LICENSEI_VERSION = 0.1.0
 
 KUSTOMIZE_BASE = config/overlays/specific-manager-version

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -353,7 +353,7 @@ func (r *ReconcileIstio) checkMeshPolicyConflict(config *istiov1beta1.Istio, log
 		if (mTLS && config.Spec.MeshPolicy.MTLSMode != istiov1beta1.STRICT) ||
 			(!mTLS && config.Spec.MeshPolicy.MTLSMode != istiov1beta1.PERMISSIVE) {
 			warningMessage := fmt.Sprintf(
-				"Value '%t' set in spec.mtls is overriden by value '%s' set in spec.meshPolicy.mtlsMode",
+				"Value '%t' set in spec.mtls is overridden by value '%s' set in spec.meshPolicy.mtlsMode",
 				mTLS,
 				config.Spec.MeshPolicy.MTLSMode,
 			)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
Update go to v1.14 and golangci-lint to 1.23.8

### Why?
Local build failed without any error messages. The missing error message is fixed by the golangci-lint update. I'm not sure why the circleci build was passing before
