### PR TITLE
pass additional config env vars from remote conf

### DIFF
--- a/pkg/remoteclusters/reconcile_config.go
+++ b/pkg/remoteclusters/reconcile_config.go
@@ -59,6 +59,7 @@ func (c *Cluster) reconcileConfig(remoteConfig *istiov1beta1.RemoteIstio, istio 
 	istioConfig.Spec.SidecarInjector.Affinity = remoteConfig.Spec.SidecarInjector.Affinity
 	istioConfig.Spec.SidecarInjector.Tolerations = remoteConfig.Spec.SidecarInjector.Tolerations
 	istioConfig.Spec.SidecarInjector.InitCNIConfiguration.Affinity = remoteConfig.Spec.SidecarInjector.InitCNIConfiguration.Affinity
+	istioConfig.Spec.SidecarInjector.InjectedContainerAdditionalEnvVars = remoteConfig.Spec.SidecarInjector.InjectedContainerAdditionalEnvVars
 
 	istioConfig.Spec.Citadel.Enabled = util.BoolPointer(true)
 	istioConfig.Spec.SidecarInjector.Enabled = util.BoolPointer(true)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no


### What's in this PR?
pass additional config env vars from remote conf, otherwise it won't be picked up by sidecar injector

