### PR TITLE
configurable wasm runtime for proxies

### DIFF
--- a/pkg/apis/istio/v1beta1/defaults.go
+++ b/pkg/apis/istio/v1beta1/defaults.go
@@ -330,6 +330,10 @@ func SetDefaults(config *Istio) {
 	if config.Spec.SidecarInjector.InitCNIConfiguration.Chained == nil {
 		config.Spec.SidecarInjector.InitCNIConfiguration.Chained = util.BoolPointer(true)
 	}
+	// Wasm Config
+	if config.Spec.ProxyWasm.Enabled == nil {
+		config.Spec.ProxyWasm.Enabled = util.BoolPointer(false)
+	}
 	// CNI repair config
 	if config.Spec.SidecarInjector.InitCNIConfiguration.Repair.Enabled == nil {
 		config.Spec.SidecarInjector.InitCNIConfiguration.Repair.Enabled = util.BoolPointer(true)

--- a/pkg/apis/istio/v1beta1/istio_types.go
+++ b/pkg/apis/istio/v1beta1/istio_types.go
@@ -324,6 +324,11 @@ type SidecarInjectorConfiguration struct {
 	InjectedContainerAdditionalEnvVars []corev1.EnvVar `json:"injectedContainerAdditionalEnvVars,omitempty"`
 }
 
+// ProxyWasmConfiguration defines config options for Envoy wasm
+type ProxyWasmConfiguration struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
 // NodeAgentConfiguration defines config options for NodeAgent
 type NodeAgentConfiguration struct {
 	Enabled                               *bool `json:"enabled,omitempty"`
@@ -652,6 +657,9 @@ type IstioSpec struct {
 
 	// SidecarInjector configuration options
 	SidecarInjector SidecarInjectorConfiguration `json:"sidecarInjector,omitempty"`
+
+	// ProxyWasm configuration options
+	ProxyWasm ProxyWasmConfiguration `json:"proxyWasm,omitempty"`
 
 	// NodeAgent configuration options
 	NodeAgent NodeAgentConfiguration `json:"nodeAgent,omitempty"`

--- a/pkg/resources/mixerlesstelemetry/mixerlesstelemetry.go
+++ b/pkg/resources/mixerlesstelemetry/mixerlesstelemetry.go
@@ -30,6 +30,8 @@ import (
 
 const (
 	componentName = "mixerless-telemetry"
+	wasmRuntime   = "envoy.wasm.runtime.v8"
+	noWasmRuntime = "envoy.wasm.runtime.null"
 )
 
 type Reconciler struct {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    |yes
| API breaks?     | no
| Deprecations?   | no


### What's in this PR?
If wasm is enabled, EnvoyFilters need to be configured differently, to pick the wasm extensions from the filesystem.