### PR TITLE
add ALS_ENABLED env var to injector config

### DIFF
--- a/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
+++ b/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
@@ -387,6 +387,10 @@ containers:
     value: "{{ .ProxyConfig.GetTracing.GetStackdriver.GetMaxNumberOfMessageEvents }}"
   {{- end }}
   {{- end }}
+{{- if .Values.global.proxy.envoyAccessLogService.enabled }}
+  - name: ISTIO_META_ALS_ENABLED
+    value: "true"
+{{- end }}
 ` + r.injectedAddtionalEnvVars() + `
   imagePullPolicy: {{ .Values.global.imagePullPolicy }}
   {{ if ne (annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` (valueOrDefault .Values.global.proxy.statusPort 0 )) ` + "`" + `0` + "`" + ` }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no|yes
| New feature?    | yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

It adds `ALS_ENABLED` env variable to sidecar injector configmap to indicate whether the proxy has ALS enabled or not.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The proxy has a static cluster to access ALS if it is turned on. It is part of the static Envoy bootstrap config.

The update from Pilot/Istiod that contains ALS settings for the listeners will break the envoy configuration and causes a crash without this static cluster.

Pilot/Istiod in our own Istio distribution is making ALS enablement decision based on this env variable to prevent the dynamic misconfiguration.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
