### PR TITLE
fix ca root remote reconciliation

### DIFF
--- a/pkg/resources/sidecarinjector/deployment.go
+++ b/pkg/resources/sidecarinjector/deployment.go
@@ -220,16 +220,18 @@ func (r *Reconciler) volumes() []apiv1.Volume {
 		})
 	}
 
-	volumes = append(volumes, apiv1.Volume{
-		Name: "istiod-ca-cert",
-		VolumeSource: apiv1.VolumeSource{
-			ConfigMap: &apiv1.ConfigMapVolumeSource{
-				LocalObjectReference: apiv1.LocalObjectReference{
-					Name: "istio-ca-root-cert",
+	if util.PointerToBool(r.Config.Spec.Istiod.Enabled) && r.Config.Spec.Pilot.CertProvider == v1beta1.PilotCertProviderTypeIstiod {
+		volumes = append(volumes, apiv1.Volume{
+			Name: "istiod-ca-cert",
+			VolumeSource: apiv1.VolumeSource{
+				ConfigMap: &apiv1.ConfigMapVolumeSource{
+					LocalObjectReference: apiv1.LocalObjectReference{
+						Name: "istio-ca-root-cert",
+					},
 				},
 			},
-		},
-	})
+		})
+	}
 
 	if r.Config.Spec.JWTPolicy == v1beta1.JWTPolicyThirdPartyJWT {
 		volumes = append(volumes, apiv1.Volume{

--- a/pkg/resources/sidecarinjector/sidecarinjector.go
+++ b/pkg/resources/sidecarinjector/sidecarinjector.go
@@ -98,7 +98,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		}
 	}
 
-	if util.PointerToBool(r.Config.Spec.SidecarInjector.Enabled) {
+	if util.PointerToBool(r.Config.Spec.SidecarInjector.Enabled) || util.PointerToBool(r.Config.Spec.Istiod.Enabled) {
 		err := r.reconcileAutoInjectionLabels(log)
 		if err != nil {
 			return emperror.WrapWith(err, "failed to label namespaces")


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixes CA root cert reconciliation to every namespace on a remote cluster in case of Istiod CA.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Trusted CA root cert must be available in a configmap in the namespaces and mounted into the pods with Envoy proxies.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
