### PR TITLE
Enhance upgrade

### DIFF
--- a/pkg/resources/citadel/citadel.go
+++ b/pkg/resources/citadel/citadel.go
@@ -129,6 +129,9 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		{DynamicResource: r.peerAuthentication, DesiredState: meshWidePolicyDesiredState},
 		{DynamicResource: r.destinationRuleDefaultMtls, DesiredState: mTLSDesiredState},
 		{DynamicResource: r.destinationRuleApiServerMtls, DesiredState: mTLSDesiredState},
+
+		// delete the old MeshPolicy CR
+		{DynamicResource: r.meshPolicy, DesiredState: k8sutil.DesiredStateAbsent},
 	}
 
 	for _, dr := range drs {

--- a/pkg/resources/citadel/mtls.go
+++ b/pkg/resources/citadel/mtls.go
@@ -108,3 +108,17 @@ func (r *Reconciler) destinationRuleApiServerMtls() *k8sutil.DynamicObject {
 		Owner: r.Config,
 	}
 }
+
+// meshPolicy returns the old MeshPolicy object
+func (r *Reconciler) meshPolicy() *k8sutil.DynamicObject {
+	return &k8sutil.DynamicObject{
+		Gvr: schema.GroupVersionResource{
+			Group:    "authentication.istio.io",
+			Version:  "v1alpha1",
+			Resource: "meshpolicies",
+		},
+		Kind:  "MeshPolicy",
+		Name:  "default",
+		Owner: r.Config,
+	}
+}

--- a/pkg/resources/mixerlesstelemetry/meta_exchange_filter_old.go
+++ b/pkg/resources/mixerlesstelemetry/meta_exchange_filter_old.go
@@ -24,7 +24,7 @@ import (
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
 )
 
-func (r *Reconciler) metaExchangeEnvoyFilterOld() *k8sutil.DynamicObject {
+func (r *Reconciler) metaExchangeEnvoyFilter15Deprecated() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
 		Gvr: schema.GroupVersionResource{
 			Group:    "networking.istio.io",

--- a/pkg/resources/mixerlesstelemetry/meta_exchange_filter_old.go
+++ b/pkg/resources/mixerlesstelemetry/meta_exchange_filter_old.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mixerlesstelemetry
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+)
+
+func (r *Reconciler) metaExchangeEnvoyFilterOld() *k8sutil.DynamicObject {
+	return &k8sutil.DynamicObject{
+		Gvr: schema.GroupVersionResource{
+			Group:    "networking.istio.io",
+			Version:  "v1alpha3",
+			Resource: "envoyfilters",
+		},
+		Kind:      "EnvoyFilter",
+		Name:      fmt.Sprintf("%s-metadata-exchange", componentName),
+		Namespace: r.Config.Namespace,
+		Owner:     r.Config,
+	}
+}

--- a/pkg/resources/mixerlesstelemetry/mixerlesstelemetry.go
+++ b/pkg/resources/mixerlesstelemetry/mixerlesstelemetry.go
@@ -78,12 +78,12 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		{DynamicResource: r.httpStatsFilter16, DesiredState: statsFilterDesiredState},
 		{DynamicResource: r.tcpStatsFilter16, DesiredState: statsFilterDesiredState},
 
-		// delete old EnvoyFilters without version names
+		// delete deprecated 1.5 EnvoyFilters without version names
 		// these lines can be removed when upgrading to 1.7
-		{DynamicResource: r.metaExchangeEnvoyFilterOld, DesiredState: k8sutil.DesiredStateAbsent},
-		{DynamicResource: r.tcpMetaExchangeEnvoyFilterOld, DesiredState: k8sutil.DesiredStateAbsent},
-		{DynamicResource: r.httpStatsFilterOld, DesiredState: k8sutil.DesiredStateAbsent},
-		{DynamicResource: r.tcpStatsFilterOld, DesiredState: k8sutil.DesiredStateAbsent},
+		{DynamicResource: r.metaExchangeEnvoyFilter15Deprecated, DesiredState: k8sutil.DesiredStateAbsent},
+		{DynamicResource: r.tcpMetaExchangeEnvoyFilter15Deprecated, DesiredState: k8sutil.DesiredStateAbsent},
+		{DynamicResource: r.httpStatsFilter15Deprecated, DesiredState: k8sutil.DesiredStateAbsent},
+		{DynamicResource: r.tcpStatsFilter15Deprecated, DesiredState: k8sutil.DesiredStateAbsent},
 	}
 
 	for _, dr := range drs {

--- a/pkg/resources/mixerlesstelemetry/mixerlesstelemetry.go
+++ b/pkg/resources/mixerlesstelemetry/mixerlesstelemetry.go
@@ -77,6 +77,13 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		{DynamicResource: r.tcpMetaExchangeEnvoyFilter16, DesiredState: exchangeFilterDesiredState},
 		{DynamicResource: r.httpStatsFilter16, DesiredState: statsFilterDesiredState},
 		{DynamicResource: r.tcpStatsFilter16, DesiredState: statsFilterDesiredState},
+
+		// delete old EnvoyFilters without version names
+		// these lines can be removed when upgrading to 1.7
+		{DynamicResource: r.metaExchangeEnvoyFilterOld, DesiredState: k8sutil.DesiredStateAbsent},
+		{DynamicResource: r.tcpMetaExchangeEnvoyFilterOld, DesiredState: k8sutil.DesiredStateAbsent},
+		{DynamicResource: r.httpStatsFilterOld, DesiredState: k8sutil.DesiredStateAbsent},
+		{DynamicResource: r.tcpStatsFilterOld, DesiredState: k8sutil.DesiredStateAbsent},
 	}
 
 	for _, dr := range drs {

--- a/pkg/resources/mixerlesstelemetry/stats_filter_old.go
+++ b/pkg/resources/mixerlesstelemetry/stats_filter_old.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mixerlesstelemetry
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+)
+
+func (r *Reconciler) httpStatsFilterOld() *k8sutil.DynamicObject {
+	return &k8sutil.DynamicObject{
+		Gvr: schema.GroupVersionResource{
+			Group:    "networking.istio.io",
+			Version:  "v1alpha3",
+			Resource: "envoyfilters",
+		},
+		Kind:      "EnvoyFilter",
+		Name:      fmt.Sprintf("%s-stats", componentName),
+		Namespace: r.Config.Namespace,
+		Owner:     r.Config,
+	}
+}

--- a/pkg/resources/mixerlesstelemetry/stats_filter_old.go
+++ b/pkg/resources/mixerlesstelemetry/stats_filter_old.go
@@ -24,7 +24,7 @@ import (
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
 )
 
-func (r *Reconciler) httpStatsFilterOld() *k8sutil.DynamicObject {
+func (r *Reconciler) httpStatsFilter15Deprecated() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
 		Gvr: schema.GroupVersionResource{
 			Group:    "networking.istio.io",

--- a/pkg/resources/mixerlesstelemetry/tcp_meta_exchange_filter_old.go
+++ b/pkg/resources/mixerlesstelemetry/tcp_meta_exchange_filter_old.go
@@ -24,7 +24,7 @@ import (
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
 )
 
-func (r *Reconciler) tcpMetaExchangeEnvoyFilterOld() *k8sutil.DynamicObject {
+func (r *Reconciler) tcpMetaExchangeEnvoyFilter15Deprecated() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
 		Gvr: schema.GroupVersionResource{
 			Group:    "networking.istio.io",

--- a/pkg/resources/mixerlesstelemetry/tcp_meta_exchange_filter_old.go
+++ b/pkg/resources/mixerlesstelemetry/tcp_meta_exchange_filter_old.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mixerlesstelemetry
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+)
+
+func (r *Reconciler) tcpMetaExchangeEnvoyFilterOld() *k8sutil.DynamicObject {
+	return &k8sutil.DynamicObject{
+		Gvr: schema.GroupVersionResource{
+			Group:    "networking.istio.io",
+			Version:  "v1alpha3",
+			Resource: "envoyfilters",
+		},
+		Kind:      "EnvoyFilter",
+		Name:      fmt.Sprintf("%s-tcp-metadata-exchange", componentName),
+		Namespace: r.Config.Namespace,
+		Owner:     r.Config,
+	}
+}

--- a/pkg/resources/mixerlesstelemetry/tcp_stats_filter_old.go
+++ b/pkg/resources/mixerlesstelemetry/tcp_stats_filter_old.go
@@ -24,7 +24,7 @@ import (
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
 )
 
-func (r *Reconciler) tcpStatsFilterOld() *k8sutil.DynamicObject {
+func (r *Reconciler) tcpStatsFilter15Deprecated() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
 		Gvr: schema.GroupVersionResource{
 			Group:    "networking.istio.io",

--- a/pkg/resources/mixerlesstelemetry/tcp_stats_filter_old.go
+++ b/pkg/resources/mixerlesstelemetry/tcp_stats_filter_old.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mixerlesstelemetry
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+)
+
+func (r *Reconciler) tcpStatsFilterOld() *k8sutil.DynamicObject {
+	return &k8sutil.DynamicObject{
+		Gvr: schema.GroupVersionResource{
+			Group:    "networking.istio.io",
+			Version:  "v1alpha3",
+			Resource: "envoyfilters",
+		},
+		Kind:      "EnvoyFilter",
+		Name:      fmt.Sprintf("%s-tcp-stats", componentName),
+		Namespace: r.Config.Namespace,
+		Owner:     r.Config,
+	}
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | sort of
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

There are resources which are created for Istio 1.5 and then should be deleted for Istio 1.6:
- "default" MeshPolicy CR (because PeerAuthentication CRD is used for the same purpose in 1.6)
- EnvoyFilters for Mixerless Telemetry (their naming has changed which is why old ones are not deleted without this PR)

This PR makes sure those are deleted.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested

