### PR TITLE
Make targetPort in MeshGateways optional

### DIFF
--- a/deploy/charts/istio-operator/templates/meshgateway-crd-1.6.yaml
+++ b/deploy/charts/istio-operator/templates/meshgateway-crd-1.6.yaml
@@ -119,7 +119,7 @@ spec:
                 required:
                 - port
                 type: object
-              minItems: 1
+              minItems: 0
               type: array
             replicaCount:
               format: int32

--- a/pkg/apis/istio/v1beta1/defaults.go
+++ b/pkg/apis/istio/v1beta1/defaults.go
@@ -112,16 +112,16 @@ const PortStatusPortNumber = 15021
 const PortStatusPortName = "status-port"
 
 var defaultIngressGatewayPorts = []ServicePort{
-	{ServicePort: corev1.ServicePort{Port: PortStatusPortNumber, Protocol: apiv1.ProtocolTCP, Name: PortStatusPortName}, TargetPort: PortStatusPortNumber},
-	{ServicePort: corev1.ServicePort{Port: 80, Protocol: apiv1.ProtocolTCP, Name: "http2"}, TargetPort: 8080},
-	{ServicePort: corev1.ServicePort{Port: 443, Protocol: apiv1.ProtocolTCP, Name: "https"}, TargetPort: 8443},
-	{ServicePort: corev1.ServicePort{Port: 15443, Protocol: apiv1.ProtocolTCP, Name: "tls"}, TargetPort: 15443},
+	{ServicePort: corev1.ServicePort{Port: PortStatusPortNumber, Protocol: apiv1.ProtocolTCP, Name: PortStatusPortName}, TargetPort: util.IntPointer(PortStatusPortNumber)},
+	{ServicePort: corev1.ServicePort{Port: 80, Protocol: apiv1.ProtocolTCP, Name: "http2"}, TargetPort: util.IntPointer(8080)},
+	{ServicePort: corev1.ServicePort{Port: 443, Protocol: apiv1.ProtocolTCP, Name: "https"}, TargetPort: util.IntPointer(8443)},
+	{ServicePort: corev1.ServicePort{Port: 15443, Protocol: apiv1.ProtocolTCP, Name: "tls"}, TargetPort: util.IntPointer(15443)},
 }
 
 var defaultEgressGatewayPorts = []ServicePort{
-	{ServicePort: corev1.ServicePort{Port: 80, Protocol: apiv1.ProtocolTCP, Name: "http2"}, TargetPort: 8080},
-	{ServicePort: corev1.ServicePort{Port: 443, Protocol: apiv1.ProtocolTCP, Name: "https"}, TargetPort: 8443},
-	{ServicePort: corev1.ServicePort{Port: 15443, Protocol: apiv1.ProtocolTCP, Name: "tls"}, TargetPort: 15443},
+	{ServicePort: corev1.ServicePort{Port: 80, Protocol: apiv1.ProtocolTCP, Name: "http2"}, TargetPort: util.IntPointer(8080)},
+	{ServicePort: corev1.ServicePort{Port: 443, Protocol: apiv1.ProtocolTCP, Name: "https"}, TargetPort: util.IntPointer(8443)},
+	{ServicePort: corev1.ServicePort{Port: 15443, Protocol: apiv1.ProtocolTCP, Name: "tls"}, TargetPort: util.IntPointer(15443)},
 }
 
 func SetDefaults(config *Istio) {

--- a/pkg/apis/istio/v1beta1/istio_types.go
+++ b/pkg/apis/istio/v1beta1/istio_types.go
@@ -186,7 +186,7 @@ type GatewaySDSConfiguration struct {
 
 type ServicePort struct {
 	corev1.ServicePort `json:",inline"`
-	TargetPort         int32 `json:"targetPort,omitempty"`
+	TargetPort         *int32 `json:"targetPort,omitempty"`
 }
 
 type ServicePorts []ServicePort
@@ -194,13 +194,16 @@ type ServicePorts []ServicePort
 func (ps ServicePorts) Convert() []corev1.ServicePort {
 	ports := make([]corev1.ServicePort, 0)
 	for _, po := range ps {
-		ports = append(ports, corev1.ServicePort{
-			Name:       po.Name,
-			Protocol:   po.Protocol,
-			Port:       po.Port,
-			TargetPort: intstr.FromInt(int(po.TargetPort)),
-			NodePort:   po.NodePort,
-		})
+		port := corev1.ServicePort{
+			Name:     po.Name,
+			Protocol: po.Protocol,
+			Port:     po.Port,
+			NodePort: po.NodePort,
+		}
+		if po.TargetPort != nil {
+			port.TargetPort = intstr.FromInt(int(util.PointerToInt32(po.TargetPort)))
+		}
+		ports = append(ports, port)
 	}
 
 	return ports

--- a/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/istio/v1beta1/zz_generated.deepcopy.go
@@ -440,7 +440,9 @@ func (in *GatewayConfiguration) DeepCopyInto(out *GatewayConfiguration) {
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]ServicePort, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.Enabled != nil {
 		in, out := &in.Enabled, &out.Enabled
@@ -1075,7 +1077,9 @@ func (in *MeshGatewaySpec) DeepCopyInto(out *MeshGatewaySpec) {
 	if in.Ports != nil {
 		in, out := &in.Ports, &out.Ports
 		*out = make([]ServicePort, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	return
 }
@@ -1676,6 +1680,11 @@ func (in *SDSConfiguration) DeepCopy() *SDSConfiguration {
 func (in *ServicePort) DeepCopyInto(out *ServicePort) {
 	*out = *in
 	out.ServicePort = in.ServicePort
+	if in.TargetPort != nil {
+		in, out := &in.TargetPort, &out.TargetPort
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 
@@ -1694,7 +1703,9 @@ func (in ServicePorts) DeepCopyInto(out *ServicePorts) {
 	{
 		in := &in
 		*out = make(ServicePorts, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 		return
 	}
 }

--- a/pkg/resources/gateways/deployment.go
+++ b/pkg/resources/gateways/deployment.go
@@ -148,8 +148,12 @@ func (r *Reconciler) getEnvoyServiceConfigurationJSON(config istiov1beta1.EnvoyS
 func (r *Reconciler) ports() []apiv1.ContainerPort {
 	var ports []apiv1.ContainerPort
 	for _, port := range r.gw.Spec.Ports {
+		tp := port.Port
+		if port.TargetPort != nil {
+			tp = *port.TargetPort
+		}
 		ports = append(ports, apiv1.ContainerPort{
-			ContainerPort: port.TargetPort, Protocol: port.Protocol, Name: port.Name,
+			ContainerPort: tp, Protocol: port.Protocol, Name: port.Name,
 		})
 	}
 	ports = append(ports, apiv1.ContainerPort{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no|yes
| API breaks?     | no|yes
| Deprecations?   | no|yes
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

It makes *targetPort* optional in *MeshGateway* resource.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The current implementation requires setting *targetPort* in the CR.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
