### PR TITLE
Change webhook order in MutatingWebhook

### DIFF
--- a/pkg/resources/sidecarinjector/webhook.go
+++ b/pkg/resources/sidecarinjector/webhook.go
@@ -124,14 +124,17 @@ func (r *Reconciler) webhook() runtime.Object {
 			matchExpression = append(matchExpression, revisionLabelMatchExpression...)
 		} else {
 			matchExpression = append(matchExpression, globalMatchExpression...)
-			wh := webhook.DeepCopy()
-			wh.NamespaceSelector.MatchExpressions = revisionLabelMatchExpression
-			webhookConfiguration.Webhooks = append(webhookConfiguration.Webhooks, *wh)
 		}
 	}
 
 	webhook.NamespaceSelector.MatchExpressions = matchExpression
 	webhookConfiguration.Webhooks = append(webhookConfiguration.Webhooks, *webhook)
+
+	if !util.PointerToBool(r.Config.Spec.SidecarInjector.EnableNamespacesByDefault) && util.PointerToBool(r.Config.Spec.Istiod.Enabled) && !r.Config.IsRevisionUsed() {
+		wh := webhook.DeepCopy()
+		wh.NamespaceSelector.MatchExpressions = revisionLabelMatchExpression
+		webhookConfiguration.Webhooks = append(webhookConfiguration.Webhooks, *wh)
+	}
 
 	return webhookConfiguration
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Mutatingwebhook had the following two webhooks defined in this order:
1. revision based webhook (for revisioned apps)
2. global webhook (for usual istio-injection=enabled labeled apps)

This PR changes the order.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Because istiod only patches the caBundle to the first mutating webhook. This way only revisioned workloads could work, but not global ones when injecting sidecars.

With this fix global ones will work as they should, for the revisioned ones istiod will be changed to not only patch the first webhook.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested

