### PR TITLE
Update configmap_sidecar_injector.go

### DIFF
--- a/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
+++ b/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
@@ -357,6 +357,10 @@ containers:
   - name: ISTIO_META_ALS_ENABLED
     value: "true"
 {{- end }}
+{{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+  - name: {{ $key }}
+    value: "{{ $value }}"
+{{- end }}
 ` + r.injectedAddtionalEnvVars() + `
   imagePullPolicy: {{ .Values.global.imagePullPolicy }}
   {{ if ne (annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` (valueOrDefault .Values.global.proxy.statusPort 0 )) ` + "`" + `0` + "`" + ` }}


### PR DESCRIPTION
https://github.com/banzaicloud/istio-operator/issues/489

proxy.istio.io/config annotation does not create env variable in istio-proxy container

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #489
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
istio-sidecar-injector does not add proxyConfig.proxyMeta env vars to istio-container

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
Because istio-sidecar-injector configmap does not read proxyConfig.proxyMetadata vars in istio-proxy container

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [X ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
Bump up operator image version to 0.7.0 from 0.6.9