### PR TITLE
proxy.istio.io/config annotation does not create env variable in side car #489

### DIFF
--- a/deploy/charts/istio-operator/Chart.yaml
+++ b/deploy/charts/istio-operator/Chart.yaml
@@ -4,5 +4,5 @@ version: 0.0.58
 description: istio-operator manages Istio deployments on Kubernetes
 sources:
   - https://github.com/banzaicloud/istio-operator
-appVersion: 0.6.9
+appVersion: 0.7.0
 icon: https://istio.io/img/istio-logo-social-blue-background.svg

--- a/deploy/charts/istio-operator/README.md
+++ b/deploy/charts/istio-operator/README.md
@@ -32,7 +32,7 @@ The following table lists the configurable parameters of the Banzaicloud Istio O
 Parameter | Description | Default
 --------- | ----------- | -------
 `operator.image.repository` | Operator container image repository | `banzaicloud/istio-operator`
-`operator.image.tag` | Operator container image tag | `0.6.9`
+`operator.image.tag` | Operator container image tag | `0.7.0`
 `operator.image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `operator.resources` | CPU/Memory resource requests/limits (YAML) | Memory: `256Mi`, CPU: `200m`
 `istioVersion` | Supported Istio version | `1.6`

--- a/deploy/charts/istio-operator/values.yaml
+++ b/deploy/charts/istio-operator/values.yaml
@@ -5,7 +5,7 @@
 operator:
   image:
     repository: banzaicloud/istio-operator
-    tag: 0.6.9
+    tag: 0.7.0
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -141,10 +141,10 @@ Alternatively, you can deploy the operator using a [Helm chart](https://github.c
 
 ```bash
 $ helm repo add banzaicloud-stable https://kubernetes-charts.banzaicloud.com
-$ helm upgrade istio-operator --install --namespace=istio-system --set-string operator.image.tag=0.6.9 banzaicloud-stable/istio-operator
+$ helm upgrade istio-operator --install --namespace=istio-system --set-string operator.image.tag=0.7.0 banzaicloud-stable/istio-operator
 ```
 
-*Note: As of now, the `0.6.9` tag is the latest version of our operator to support Istio versions 1.6.x*
+*Note: As of now, the `0.7.0` tag is the latest version of our operator to support Istio versions 1.6.x*
 
 **Use the new Custom Resource**
 

--- a/pkg/apis/istio/v1beta1/istio_types.go
+++ b/pkg/apis/istio/v1beta1/istio_types.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	SupportedIstioVersion = "1.6.8"
-	Version               = "0.6.9"
+	Version               = "0.7.0"
 )
 
 // IstioVersion stores the intended Istio version

--- a/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
+++ b/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
@@ -357,6 +357,10 @@ containers:
   - name: ISTIO_META_ALS_ENABLED
     value: "true"
 {{- end }}
+{{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+  - name: {{ $key }}
+    value: "{{ $value }}"
+{{- end }}
 ` + r.injectedAddtionalEnvVars() + `
   imagePullPolicy: {{ .Values.global.imagePullPolicy }}
   {{ if ne (annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` (valueOrDefault .Values.global.proxy.statusPort 0 )) ` + "`" + `0` + "`" + ` }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #489
| License         | Apache 2.0


### What's in this PR?
proxy.istio.io/config annotation does not add env vars to istio-proxy container

### Why?
istio-sidecar-injector configmap does not read proxy config var inside istio-proxy container


### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ X] User guide and development docs updated (if needed)
