### PR TITLE
proxy.istio.io/config annotation does not add env variable in istio-proxy container

### DIFF
--- a/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
+++ b/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
@@ -357,6 +357,10 @@ containers:
   - name: ISTIO_META_ALS_ENABLED
     value: "true"
 {{- end }}
+{{- range $key, $value := .ProxyConfig.ProxyMetadata }}
+  - name: {{ $key }}
+    value: "{{ $value }}"
+{{- end }}
 ` + r.injectedAddtionalEnvVars() + `
   imagePullPolicy: {{ .Values.global.imagePullPolicy }}
   {{ if ne (annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` (valueOrDefault .Values.global.proxy.statusPort 0 )) ` + "`" + `0` + "`" + ` }}


### PR DESCRIPTION
https://github.com/banzaicloud/istio-operator/issues/489

proxy.istio.io/config annotation does not create env variable in istio-proxy container

| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #489
| License         | Apache 2.0


### What's in this PR?
proxy.istio.io/config annotation does not add env variable in istio-proxy container


### Why?
side injector configmap does not read proxy config annotations env vars in istio container

