### PR TITLE
Rolling re-create support for Istiod and MGW deployments

### DIFF
--- a/pkg/controller/meshgateway/meshgateway_controller.go
+++ b/pkg/controller/meshgateway/meshgateway_controller.go
@@ -158,7 +158,7 @@ func (r *ReconcileMeshGateway) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, errors.WithStack(err)
 	}
 
-	reconciler := gateways.New(r.Client, r.dynamic, istio, instance)
+	reconciler := gateways.New(r.Client, r.dynamic, istio, instance, r.scheme)
 
 	err = reconciler.Reconcile(log)
 	if err == nil {

--- a/pkg/k8sutil/desired_state.go
+++ b/pkg/k8sutil/desired_state.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2019 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"context"
+	"time"
+
+	"github.com/banzaicloud/istio-operator/pkg/k8sutil/wait"
+	"github.com/banzaicloud/istio-operator/pkg/util"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type DesiredState interface {
+	AfterRecreate(current, desired runtime.Object) error
+	BeforeRecreate(current, desired runtime.Object) error
+}
+
+type StaticDesiredState string
+
+func (s StaticDesiredState) AfterRecreate(current, desired runtime.Object) error {
+	return nil
+}
+
+func (s StaticDesiredState) BeforeRecreate(current, desired runtime.Object) error {
+	return nil
+}
+
+const (
+	DesiredStatePresent StaticDesiredState = "present"
+	DesiredStateAbsent  StaticDesiredState = "absent"
+	DesiredStateExists  StaticDesiredState = "exists"
+)
+
+type RecreateAwareDesiredState struct {
+	afterCreateFunc  func(current, desired runtime.Object) error
+	beforeCreateFunc func(current, desired runtime.Object) error
+}
+
+func NewRecreateAwareDesiredState(afterCreateFunc, beforeCreateFunc func(current, desired runtime.Object) error) RecreateAwareDesiredState {
+	return RecreateAwareDesiredState{
+		afterCreateFunc:  afterCreateFunc,
+		beforeCreateFunc: beforeCreateFunc,
+	}
+}
+
+func (s RecreateAwareDesiredState) AfterRecreate(current, desired runtime.Object) error {
+	return s.afterCreateFunc(current, desired)
+}
+
+func (s RecreateAwareDesiredState) BeforeRecreate(current, desired runtime.Object) error {
+	return s.beforeCreateFunc(current, desired)
+}
+
+func DeploymentDesiredStateWithReCreateHandling(c client.Client, scheme *runtime.Scheme, log logr.Logger, podLabels map[string]string) RecreateAwareDesiredState {
+	podLabels = util.MergeMultipleStringMaps(map[string]string{
+		"detached": "true",
+	}, podLabels)
+
+	return NewRecreateAwareDesiredState(
+		// after re-create
+		func(current, desired runtime.Object) error {
+			var deployment *appsv1.Deployment
+			var ok bool
+			if deployment, ok = desired.(*appsv1.Deployment); !ok {
+				return nil
+			}
+
+			rcc := wait.NewResourceConditionChecks(c, wait.Backoff{
+				Duration: time.Second * 5,
+				Factor:   1,
+				Jitter:   0,
+				Steps:    12,
+			}, log.WithName("wait"), scheme)
+
+			err := rcc.WaitForResources("readiness", []runtime.Object{deployment}, wait.ExistsConditionCheck, wait.ReadyReplicasConditionCheck)
+			if err != nil {
+				return err
+			}
+
+			pods := &corev1.PodList{}
+			err = c.List(context.Background(), &client.ListOptions{
+				Namespace:     deployment.GetNamespace(),
+				LabelSelector: labels.Set(podLabels).AsSelector(),
+			}, pods)
+			if err != nil {
+				return err
+			}
+			for _, pod := range pods.Items {
+				log.Info("removing detached pods")
+				err = c.Delete(context.Background(), &pod)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		},
+		// before re-create
+		func(current, desired runtime.Object) error {
+			var deployment *appsv1.Deployment
+			var ok bool
+			if deployment, ok = current.(*appsv1.Deployment); !ok {
+				return nil
+			}
+
+			err := DetachPodsFromDeployment(c, deployment, log, podLabels)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		})
+}

--- a/pkg/k8sutil/desired_state.go
+++ b/pkg/k8sutil/desired_state.go
@@ -41,11 +41,11 @@ type DesiredState interface {
 
 type StaticDesiredState string
 
-func (s StaticDesiredState) AfterRecreate(current, desired runtime.Object) error {
+func (s StaticDesiredState) AfterRecreate(_, _ runtime.Object) error {
 	return nil
 }
 
-func (s StaticDesiredState) BeforeRecreate(current, desired runtime.Object) error {
+func (s StaticDesiredState) BeforeRecreate(_, _ runtime.Object) error {
 	return nil
 }
 

--- a/pkg/k8sutil/desired_state.go
+++ b/pkg/k8sutil/desired_state.go
@@ -30,6 +30,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	detachedPodLabel = "istio.banzaicloud.io/detached-pod"
+)
+
 type DesiredState interface {
 	AfterRecreate(current, desired runtime.Object) error
 	BeforeRecreate(current, desired runtime.Object) error
@@ -73,7 +77,7 @@ func (s RecreateAwareDesiredState) BeforeRecreate(current, desired runtime.Objec
 
 func DeploymentDesiredStateWithReCreateHandling(c client.Client, scheme *runtime.Scheme, log logr.Logger, podLabels map[string]string) RecreateAwareDesiredState {
 	podLabels = util.MergeMultipleStringMaps(map[string]string{
-		"detached": "true",
+		detachedPodLabel: "true",
 	}, podLabels)
 
 	return NewRecreateAwareDesiredState(

--- a/pkg/k8sutil/detach_pod.go
+++ b/pkg/k8sutil/detach_pod.go
@@ -43,7 +43,7 @@ func DetachPodsFromDeployment(c client.Client, deployment *appsv1.Deployment, lo
 
 	for _, pod := range pods.Items {
 		if len(pod.OwnerReferences) != 1 {
-			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "notExactlyOneOwnerReference")
+			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "notExactlyOneOwnerReferenceForPod")
 			continue
 		}
 		ownerRef := pod.OwnerReferences[0]
@@ -61,7 +61,7 @@ func DetachPodsFromDeployment(c client.Client, deployment *appsv1.Deployment, lo
 		}
 
 		if len(rs.OwnerReferences) != 1 {
-			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "replicaSetHasMultipleOwners")
+			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "notExactlyOneOwnerReferenceForReplicaSet")
 			continue
 		}
 

--- a/pkg/k8sutil/detach_pod.go
+++ b/pkg/k8sutil/detach_pod.go
@@ -1,16 +1,18 @@
-// Copyright © 2019 Banzai Cloud
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2019 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package k8sutil
 
@@ -41,10 +43,12 @@ func DetachPodsFromDeployment(c client.Client, deployment *appsv1.Deployment, lo
 
 	for _, pod := range pods.Items {
 		if len(pod.OwnerReferences) != 1 {
+			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "noOwnerReferences")
 			continue
 		}
 		ownerRef := pod.OwnerReferences[0]
 		if ownerRef.Kind != "ReplicaSet" {
+			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "ownerIsNotReplicaSet")
 			continue
 		}
 		rs := &appsv1.ReplicaSet{}
@@ -57,14 +61,16 @@ func DetachPodsFromDeployment(c client.Client, deployment *appsv1.Deployment, lo
 		}
 
 		if len(rs.OwnerReferences) != 1 {
+			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "replicaSetHasMultipleOwners")
 			continue
 		}
 
 		if rs.OwnerReferences[0].UID != deployment.UID {
+			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "replicaSetOwnerMismatch")
 			continue
 		}
 
-		log.V(1).Info("detaching pod", "deploymentName", deployment.Name, "name", pod.Name)
+		log.V(1).Info("evaluting pod for detaching", "action", "detach", "deploymentName", deployment.Name, "name", pod.Name)
 
 		p := pod.DeepCopy()
 		p.OwnerReferences = nil

--- a/pkg/k8sutil/detach_pod.go
+++ b/pkg/k8sutil/detach_pod.go
@@ -43,7 +43,7 @@ func DetachPodsFromDeployment(c client.Client, deployment *appsv1.Deployment, lo
 
 	for _, pod := range pods.Items {
 		if len(pod.OwnerReferences) != 1 {
-			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "noOwnerReferences")
+			log.V(1).Info("evaluting pod for detaching", "action", "skip", "deploymentName", deployment.Name, "name", pod.Name, "reason", "notExactlyOneOwnerReference")
 			continue
 		}
 		ownerRef := pod.OwnerReferences[0]

--- a/pkg/k8sutil/detach_pod.go
+++ b/pkg/k8sutil/detach_pod.go
@@ -1,0 +1,85 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	"context"
+
+	"github.com/banzaicloud/istio-operator/pkg/util"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func DetachPodsFromDeployment(c client.Client, deployment *appsv1.Deployment, log logr.Logger, additionalLabels ...map[string]string) error {
+	ls, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return err
+	}
+
+	pods := &corev1.PodList{}
+	err = c.List(context.Background(), &client.ListOptions{
+		LabelSelector: ls,
+	}, pods)
+	if err != nil {
+		return err
+	}
+
+	for _, pod := range pods.Items {
+		if len(pod.OwnerReferences) != 1 {
+			continue
+		}
+		ownerRef := pod.OwnerReferences[0]
+		if ownerRef.Kind != "ReplicaSet" {
+			continue
+		}
+		rs := &appsv1.ReplicaSet{}
+		err = c.Get(context.Background(), client.ObjectKey{
+			Name:      ownerRef.Name,
+			Namespace: pod.Namespace,
+		}, rs)
+		if err != nil {
+			return err
+		}
+
+		if len(rs.OwnerReferences) != 1 {
+			continue
+		}
+
+		if rs.OwnerReferences[0].UID != deployment.UID {
+			continue
+		}
+
+		log.V(1).Info("detaching pod", "deploymentName", deployment.Name, "name", pod.Name)
+
+		p := pod.DeepCopy()
+		p.OwnerReferences = nil
+		if p.Labels == nil {
+			p.Labels = make(map[string]string)
+		} else {
+			delete(p.Labels, "pod-template-hash")
+		}
+		p.Labels = util.MergeStringMaps(p.Labels, util.MergeMultipleStringMaps(additionalLabels...))
+
+		err = c.Update(context.Background(), p)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/k8sutil/unstructured.go
+++ b/pkg/k8sutil/unstructured.go
@@ -32,14 +32,6 @@ import (
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
-type DesiredState string
-
-const (
-	DesiredStatePresent DesiredState = "present"
-	DesiredStateAbsent  DesiredState = "absent"
-	DesiredStateExists  DesiredState = "exists"
-)
-
 type DynamicObject struct {
 	Name      string
 	Namespace string
@@ -51,7 +43,7 @@ type DynamicObject struct {
 }
 
 func (d *DynamicObject) Reconcile(log logr.Logger, client dynamic.Interface, desiredState DesiredState) error {
-	if desiredState == "" {
+	if desiredState == nil {
 		desiredState = DesiredStatePresent
 	}
 	desired := d.unstructured()

--- a/pkg/k8sutil/wait/checks.go
+++ b/pkg/k8sutil/wait/checks.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package wait
 
 import (

--- a/pkg/k8sutil/wait/checks.go
+++ b/pkg/k8sutil/wait/checks.go
@@ -1,0 +1,60 @@
+package wait
+
+import (
+	"github.com/banzaicloud/istio-operator/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type ResourceConditionCheck func(runtime.Object, error) bool
+type CustomResourceConditionCheck func() (bool, error)
+
+func ExistsConditionCheck(obj runtime.Object, k8serror error) bool {
+	return k8serror == nil
+}
+
+func NonExistsConditionCheck(obj runtime.Object, k8serror error) bool {
+	return k8serrors.IsNotFound(k8serror)
+}
+
+func CRDEstablishedConditionCheck(obj runtime.Object, k8serror error) bool {
+	var resource *apiextensionsv1beta1.CustomResourceDefinition
+	var ok bool
+	if resource, ok = obj.(*apiextensionsv1beta1.CustomResourceDefinition); !ok {
+		return true
+	}
+
+	for _, condition := range resource.Status.Conditions {
+		if condition.Type == apiextensionsv1beta1.Established {
+			if condition.Status == apiextensionsv1beta1.ConditionTrue {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func ReadyReplicasConditionCheck(obj runtime.Object, k8serror error) bool {
+	var deployment *appsv1.Deployment
+	var ok bool
+
+	if deployment, ok = obj.(*appsv1.Deployment); ok {
+		return util.PointerToInt32(deployment.Spec.Replicas) == deployment.Status.ReadyReplicas && deployment.Status.ReadyReplicas == deployment.Status.Replicas
+	}
+
+	var statefulset *appsv1.StatefulSet
+	if statefulset, ok = obj.(*appsv1.StatefulSet); ok {
+		return util.PointerToInt32(statefulset.Spec.Replicas) == statefulset.Status.ReadyReplicas && statefulset.Status.ReadyReplicas == statefulset.Status.Replicas
+	}
+
+	var daemonset *appsv1.DaemonSet
+	if daemonset, ok = obj.(*appsv1.DaemonSet); ok {
+		return daemonset.Status.DesiredNumberScheduled == daemonset.Status.NumberReady
+	}
+
+	// return true for unconvertable objects
+	return true
+}

--- a/pkg/k8sutil/wait/wait.go
+++ b/pkg/k8sutil/wait/wait.go
@@ -1,16 +1,18 @@
-// Copyright © 2019 Banzai Cloud
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2019 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package wait
 

--- a/pkg/k8sutil/wait/wait.go
+++ b/pkg/k8sutil/wait/wait.go
@@ -1,0 +1,179 @@
+// Copyright © 2019 Banzai Cloud
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wait
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/goph/emperror"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type Backoff wait.Backoff
+
+type ResourceConditionChecks struct {
+	client  client.Client
+	backoff wait.Backoff
+	log     logr.Logger
+	scheme  *runtime.Scheme
+}
+
+func NewResourceConditionChecks(client client.Client, backoff Backoff, log logr.Logger, scheme *runtime.Scheme) *ResourceConditionChecks {
+	return &ResourceConditionChecks{
+		client:  client,
+		backoff: wait.Backoff(backoff),
+		log:     log,
+		scheme:  scheme,
+	}
+}
+
+func (c *ResourceConditionChecks) WaitForCustomConditionChecks(id string, checkFuncs ...CustomResourceConditionCheck) error {
+	log := c.log.WithName(id)
+
+	if l, ok := log.(interface{ Grouped(state bool) }); ok {
+		l.Grouped(true)
+		defer l.Grouped(false)
+	}
+
+	log.Info("waiting")
+
+	err := wait.ExponentialBackoff(c.backoff, func() (bool, error) {
+		for _, fn := range checkFuncs {
+			if ok, err := fn(); !ok {
+				if err != nil {
+					return false, err
+				}
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.Info("done")
+
+	return nil
+}
+
+func (c *ResourceConditionChecks) WaitForResources(id string, objects []runtime.Object, checkFuncs ...ResourceConditionCheck) error {
+	if len(objects) == 0 || len(checkFuncs) == 0 {
+		return nil
+	}
+
+	log := c.log.WithName(id)
+
+	if l, ok := log.(interface{ Grouped(state bool) }); ok {
+		l.Grouped(true)
+		defer l.Grouped(false)
+	}
+
+	log.Info("waiting")
+
+	for _, o := range objects {
+		err := c.waitForResourceConditions(o, log, checkFuncs...)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Info("done")
+
+	return nil
+}
+
+func (c *ResourceConditionChecks) waitForResourceConditions(object runtime.Object, log logr.Logger, checkFuncs ...ResourceConditionCheck) error {
+	resource := object.DeepCopyObject()
+
+	key, err := client.ObjectKeyFromObject(resource)
+	if err != nil {
+		return emperror.Wrap(err, "failed to get object key")
+	}
+
+	log = log.WithValues(c.resourceDetails(resource)...)
+
+	log.V(1).Info("pending")
+	err = wait.ExponentialBackoff(c.backoff, func() (bool, error) {
+		err := c.client.Get(context.Background(), types.NamespacedName{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		}, resource)
+		for _, fn := range checkFuncs {
+			ok := fn(resource, err)
+			if !ok {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	log.V(1).Info("ok")
+
+	return nil
+}
+
+func (c *ResourceConditionChecks) resourceDetails(desired runtime.Object) []interface{} {
+	values := make([]interface{}, 0)
+
+	key, err := client.ObjectKeyFromObject(desired)
+	if err == nil {
+		values = append(values, "name", key.Name)
+		if key.Namespace != "" {
+			values = append(values, "namespace", key.Namespace)
+		}
+	}
+
+	gvk := desired.GetObjectKind().GroupVersionKind()
+	if gvk.Kind == "" {
+		gvko, err := apiutil.GVKForObject(desired, c.scheme)
+		if err == nil {
+			gvk = gvko
+		}
+	}
+
+	values = append(values,
+		"apiVersion", gvk.GroupVersion().String(),
+		"kind", gvk.Kind)
+
+	return values
+}
+
+func GetFormattedName(name, namespace string, gvk schema.GroupVersionKind) string {
+	var group string
+	if gvk.Group != "" {
+		group = "." + gvk.Group
+	}
+
+	if namespace != "" {
+		namespace = namespace + "/"
+	}
+	return fmt.Sprintf("%s%s:%s%s", strings.ToLower(gvk.Kind), group, namespace, name)
+}

--- a/pkg/resources/gateways/gateways.go
+++ b/pkg/resources/gateways/gateways.go
@@ -77,12 +77,8 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 		hpaDesiredState = k8sutil.DesiredStatePresent
 	}
 
-	var deploymentDesiredState k8sutil.DesiredState
-	deploymentDesiredState = k8sutil.DesiredStatePresent
 	// add specific desired state to support re-creation
-	if deploymentDesiredState == k8sutil.DesiredStatePresent {
-		deploymentDesiredState = k8sutil.DeploymentDesiredStateWithReCreateHandling(r.Client, r.scheme, log, r.labels())
-	}
+	deploymentDesiredState := k8sutil.DeploymentDesiredStateWithReCreateHandling(r.Client, r.scheme, log, r.labels())
 
 	for _, res := range []resources.ResourceWithDesiredState{
 		{Resource: r.serviceAccount, DesiredState: k8sutil.DesiredStatePresent},

--- a/pkg/resources/mixer/mixer.go
+++ b/pkg/resources/mixer/mixer.go
@@ -187,7 +187,7 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 
 	for _, dr := range drs {
 		o := dr.DynamicResource()
-		if dr.DesiredState == "" {
+		if dr.DesiredState == nil {
 			dr.DesiredState = mixerDesiredState
 		}
 		err := o.Reconcile(log, r.dynamic, dr.DesiredState)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Implements support for rolling upgrade like scenario for `immutable field change -> re-create` updates of Istiod and MeshGateway deployments.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Immutable fields of a k8s resource cannot be changed with a resource update, in that case the operator removes the existing resource and creates a new one. For a deployment that will cause service disruption since the existing pods will be terminated before the new ones come up and become ready.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
