### PR TITLE
Change shellcheck download URL

### DIFF
--- a/scripts/install_shellcheck.sh
+++ b/scripts/install_shellcheck.sh
@@ -11,7 +11,7 @@ BIN_DIR=${SCRIPT_DIR}/../bin
 mkdir -p "${BIN_DIR}"
 
 # download the release
-curl -L -O "https://shellcheck.storage.googleapis.com/shellcheck-v${version}.${opsys}.${arch}.tar.xz"
+curl -L -O "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.${opsys}.${arch}.tar.xz"
 
 # extract the archive
 tar -Jxvf "shellcheck-v${version}.${opsys}.${arch}.tar.xz" shellcheck-v${version}/shellcheck


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To fix the following error in CircleCI:
```
scripts/install_shellcheck.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   572  100   572    0     0   4973      0 --:--:-- --:--:-- --:--:--  4973
shellcheck-v0.7.0/shellcheck
Checking make target: all
You are downloading ShellCheck from an outdated URL!

Please update to the new URL:
https://github.com/koalaman/shellcheck/releases/download/v0.7.0/shellcheck-v0.7.0.linux.x86_64.tar.xz

For more information, see:
https://github.com/koalaman/shellcheck/issues/1871

PS: Sorry for breaking your build. The hosting costs were getting out of hand :(
make[1]: *** [Makefile:71: install-kubebuilder] Error 1
make: *** [Makefile:132: shellcheck-makefile] Error 1

Exited with code exit status 2
```

See: https://app.circleci.com/pipelines/github/banzaicloud/istio-operator/1311/workflows/43c37d92-15f3-40b8-985f-1aef36d0dfd2/jobs/1926

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
