### PR TITLE
Make sure that controlPlaneAuthPolicy is always set

### DIFF
--- a/pkg/apis/istio/v1beta1/istio_types.go
+++ b/pkg/apis/istio/v1beta1/istio_types.go
@@ -939,6 +939,14 @@ func (v IstioVersion) IsSupported() bool {
 	return re.Match([]byte(v))
 }
 
+func (c *Istio) GetControlPlaneAuthPolicy() ControlPlaneAuthPolicyType {
+	if c.Spec.ControlPlaneAuthPolicy != "" {
+		return c.Spec.ControlPlaneAuthPolicy
+	}
+
+	return ControlPlaneAuthPolicyMTLS
+}
+
 func (c *Istio) GetCAAddress() string {
 	if c.Spec.CAAddress != "" {
 		return c.Spec.CAAddress

--- a/pkg/resources/base/configmap.go
+++ b/pkg/resources/base/configmap.go
@@ -54,7 +54,7 @@ func MeshConfig(config *istiov1beta1.Istio, remote bool) map[string]interface{} 
 		"parentShutdownDuration": "1m0s",
 		"proxyAdminPort":         15000,
 		"concurrency":            0,
-		"controlPlaneAuthPolicy": config.Spec.ControlPlaneAuthPolicy,
+		"controlPlaneAuthPolicy": config.GetControlPlaneAuthPolicy(),
 		"discoveryAddress":       config.GetDiscoveryAddress(),
 	}
 

--- a/pkg/resources/mixer/deployment.go
+++ b/pkg/resources/mixer/deployment.go
@@ -361,7 +361,7 @@ func (r *Reconciler) istioProxyContainer(t string) apiv1.Container {
 		"--templateFile",
 		templateFile,
 		"--controlPlaneAuthPolicy",
-		string(r.Config.Spec.ControlPlaneAuthPolicy),
+		string(r.Config.GetControlPlaneAuthPolicy()),
 		"--domain",
 		fmt.Sprintf("$(POD_NAMESPACE).svc.%s", r.Config.Spec.Proxy.ClusterDomain),
 		"--trust-domain",

--- a/pkg/resources/pilot/deployment.go
+++ b/pkg/resources/pilot/deployment.go
@@ -186,7 +186,7 @@ func (r *Reconciler) containers() []apiv1.Container {
 		"--templateFile",
 		"/etc/istio/proxy/envoy_pilot.yaml.tmpl",
 		"--controlPlaneAuthPolicy",
-		string(r.Config.Spec.ControlPlaneAuthPolicy),
+		string(r.Config.GetControlPlaneAuthPolicy()),
 		"--domain",
 		r.Config.Namespace + ".svc." + r.Config.Spec.Proxy.ClusterDomain,
 		"--trust-domain",

--- a/pkg/resources/sidecarinjector/deployment.go
+++ b/pkg/resources/sidecarinjector/deployment.go
@@ -272,7 +272,7 @@ func (r *Reconciler) certFetcherContainer() apiv1.Container {
 		"--serviceCluster",
 		"istio-si-cert-fetcher",
 		"--controlPlaneAuthPolicy",
-		string(r.Config.Spec.ControlPlaneAuthPolicy),
+		string(r.Config.GetControlPlaneAuthPolicy()),
 		"--domain",
 		r.Config.Namespace + ".svc." + r.Config.Spec.Proxy.ClusterDomain,
 		"--discoveryAddress", r.Config.GetDiscoveryAddress(),


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Makes sure that `controlPlaneAuthPolicy` value is set to `MUTUAL_TLS` by default and cannot be an empty string in any cases.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

If it is an empty string then the corresponding deployment will not be able to start, because its value can only be `MUTUAL_TLS` or `NONE`, but cannot be an empty string.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

The issue happened because for the gateway deployment environment variables we fetch the "PROXY_CONFIG" where the `controlPlaneAuthPolicy` value is used and the meshgateway controller did not set this field's default value. References: 
- https://github.com/banzaicloud/istio-operator/blob/release-1.7/pkg/resources/gateways/deployment.go#L243-L251
- https://github.com/banzaicloud/istio-operator/blob/release-1.7/pkg/resources/base/configmap.go#L57
