### PR TITLE
Do NOT recreate Istio CRDs in case of update failures

### DIFF
--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -86,7 +86,7 @@ func Add(mgr manager.Manager) error {
 	if err != nil {
 		return emperror.Wrap(err, "failed to create dynamic client")
 	}
-	crd, err := crds.New(mgr.GetConfig(), istiov1beta1.SupportedIstioVersion)
+	crd, err := crds.New(mgr, mgr.GetConfig(), istiov1beta1.SupportedIstioVersion)
 	if err != nil {
 		return emperror.Wrap(err, "unable to set up CRD reconciler")
 	}

--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -86,7 +86,7 @@ func Add(mgr manager.Manager) error {
 	if err != nil {
 		return emperror.Wrap(err, "failed to create dynamic client")
 	}
-	crd, err := crds.New(mgr, mgr.GetConfig(), istiov1beta1.SupportedIstioVersion)
+	crd, err := crds.New(mgr, istiov1beta1.SupportedIstioVersion)
 	if err != nil {
 		return emperror.Wrap(err, "unable to set up CRD reconciler")
 	}

--- a/pkg/controller/istio/istio_controller_test.go
+++ b/pkg/controller/istio/istio_controller_test.go
@@ -55,7 +55,7 @@ func TestReconcile(t *testing.T) {
 	dynamic, err := dynamic.NewForConfig(mgr.GetConfig())
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	crd, err := crds.New(mgr, mgr.GetConfig(), istiov1beta1.SupportedIstioVersion)
+	crd, err := crds.New(mgr, istiov1beta1.SupportedIstioVersion)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	recFn, requests := SetupTestReconcile(newReconciler(mgr, dynamic, crd))

--- a/pkg/controller/istio/istio_controller_test.go
+++ b/pkg/controller/istio/istio_controller_test.go
@@ -55,7 +55,7 @@ func TestReconcile(t *testing.T) {
 	dynamic, err := dynamic.NewForConfig(mgr.GetConfig())
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	crd, err := crds.New(mgr.GetConfig(), istiov1beta1.SupportedIstioVersion)
+	crd, err := crds.New(mgr, mgr.GetConfig(), istiov1beta1.SupportedIstioVersion)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	recFn, requests := SetupTestReconcile(newReconciler(mgr, dynamic, crd))

--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -45,9 +45,10 @@ import (
 )
 
 const (
-	componentName  = "crds"
-	createdByLabel = "banzaicloud.io/created-by"
-	createdBy      = "istio-operator"
+	componentName     = "crds"
+	createdByLabel    = "banzaicloud.io/created-by"
+	createdBy         = "istio-operator"
+	eventRecorderName = "istio-crd-controller"
 )
 
 type CRDReconciler struct {
@@ -57,12 +58,12 @@ type CRDReconciler struct {
 	recorder record.EventRecorder
 }
 
-func New(mgr manager.Manager, cfg *rest.Config, revision string, crds ...*extensionsobj.CustomResourceDefinition) (*CRDReconciler, error) {
+func New(mgr manager.Manager, revision string, crds ...*extensionsobj.CustomResourceDefinition) (*CRDReconciler, error) {
 	r := &CRDReconciler{
 		crds:     crds,
-		config:   cfg,
+		config:   mgr.GetConfig(),
 		revision: revision,
-		recorder: mgr.GetRecorder("istio-crd-controller"),
+		recorder: mgr.GetRecorder(eventRecorderName),
 	}
 
 	return r, nil

--- a/pkg/remoteclusters/reconcile_crds.go
+++ b/pkg/remoteclusters/reconcile_crds.go
@@ -53,7 +53,7 @@ func (c *Cluster) reconcileCRDs(remoteConfig *istiov1beta1.RemoteIstio, istio *i
 		meshgatewaycrd,
 	}
 
-	crdo, err := crds.New(c.mgr, c.restConfig, istiov1beta1.Version, resources...)
+	crdo, err := crds.New(c.mgr, istiov1beta1.Version, resources...)
 	if err != nil {
 		return err
 	}

--- a/pkg/remoteclusters/reconcile_crds.go
+++ b/pkg/remoteclusters/reconcile_crds.go
@@ -53,7 +53,7 @@ func (c *Cluster) reconcileCRDs(remoteConfig *istiov1beta1.RemoteIstio, istio *i
 		meshgatewaycrd,
 	}
 
-	crdo, err := crds.New(c.restConfig, istiov1beta1.Version, resources...)
+	crdo, err := crds.New(c.mgr, c.restConfig, istiov1beta1.Version, resources...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


Cherry-pick of #522.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It might need manual CRD updates, but this way CRD recreations won't delete CRs as well, which can cause bigger issues.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
