### PR TITLE
Label namespace only if istio.io/rev label is not set

### DIFF
--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -228,11 +228,9 @@ func ReconcileNamespaceLabelsIgnoreNotFound(log logr.Logger, client runtimeClien
 		return emperror.WrapWith(err, "getting namespace failed", "namespace", namespace)
 	}
 
-	if ns.Labels != nil {
-		if _, ok := ns.Labels["istio.io/rev"]; ok {
-			log.V(1).Info("namespace has 'istio.io/rev' label, ignoring namespace", "namespace", namespace)
-			return nil
-		}
+	if _, ok := ns.Labels["istio.io/rev"]; ok {
+		log.V(1).Info("namespace has 'istio.io/rev' label, ignoring namespace", "namespace", namespace)
+		return nil
 	}
 
 	updateNeeded := false

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -230,7 +230,7 @@ func ReconcileNamespaceLabelsIgnoreNotFound(log logr.Logger, client runtimeClien
 
 	if ns.Labels != nil {
 		if _, ok := ns.Labels["istio.io/rev"]; ok {
-			log.V(1).Info("namespace has 'istio.io/rev' label, ignoring", "namespace", namespace)
+			log.V(1).Info("namespace has 'istio.io/rev' label, ignoring namespace", "namespace", namespace)
 			return nil
 		}
 	}

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -228,6 +228,13 @@ func ReconcileNamespaceLabelsIgnoreNotFound(log logr.Logger, client runtimeClien
 		return emperror.WrapWith(err, "getting namespace failed", "namespace", namespace)
 	}
 
+	if ns.Labels != nil {
+		if _, ok := ns.Labels["istio.io/rev"]; ok {
+			log.V(1).Info("namespace has 'istio.io/rev' label, ignoring", "namespace", namespace)
+			return nil
+		}
+	}
+
 	updateNeeded := false
 	for dlk, dlv := range labels {
 		if ns.Labels == nil {

--- a/pkg/k8sutil/resource.go
+++ b/pkg/k8sutil/resource.go
@@ -216,7 +216,7 @@ func IsObjectChanged(oldObj, newObj runtime.Object, ignoreStatusChange bool) (bo
 }
 
 // ReconcileNamespaceLabelsIgnoreNotFound patches namespaces by adding/removing labels, returns without error if namespace is not found
-func ReconcileNamespaceLabelsIgnoreNotFound(log logr.Logger, client runtimeClient.Client, namespace string, labels map[string]string, labelsToRemove []string) error {
+func ReconcileNamespaceLabelsIgnoreNotFound(log logr.Logger, client runtimeClient.Client, namespace string, labels map[string]string, labelsToRemove []string, customLabelsToIgnoreReconcile ...string) error {
 	var ns = &corev1.Namespace{}
 	err := client.Get(context.TODO(), runtimeClient.ObjectKey{Name: namespace}, ns)
 	if err != nil {
@@ -228,9 +228,11 @@ func ReconcileNamespaceLabelsIgnoreNotFound(log logr.Logger, client runtimeClien
 		return emperror.WrapWith(err, "getting namespace failed", "namespace", namespace)
 	}
 
-	if _, ok := ns.Labels["istio.io/rev"]; ok {
-		log.V(1).Info("namespace has 'istio.io/rev' label, ignoring namespace", "namespace", namespace)
-		return nil
+	for _, customLabel := range customLabelsToIgnoreReconcile {
+		if _, ok := ns.Labels[customLabel]; ok {
+			log.V(1).Info("namespace has a custom label, ignoring namespace", "namespace", namespace, "customLabel", customLabel)
+			return nil
+		}
 	}
 
 	updateNeeded := false

--- a/pkg/resources/sidecarinjector/labels.go
+++ b/pkg/resources/sidecarinjector/labels.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	managedAutoInjectionLabelKey = "istio-operator-managed-injection"
-	autoInjectionLabelKey        = "istio-injection"
+	managedAutoInjectionLabelKey    = "istio-operator-managed-injection"
+	autoInjectionLabelKey           = "istio-injection"
+	revisionedAutoInjectionLabelKey = "istio.io/rev"
 )
 
 func (r *Reconciler) reconcileAutoInjectionLabels(log logr.Logger) error {
@@ -41,7 +42,7 @@ func (r *Reconciler) reconcileAutoInjectionLabels(log logr.Logger) error {
 	managedNamespaces := make(map[string]bool)
 	for _, ns := range r.Config.Spec.AutoInjectionNamespaces {
 		managedNamespaces[ns] = true
-		err := k8sutil.ReconcileNamespaceLabelsIgnoreNotFound(log, r.Client, ns, autoInjectLabels, nil)
+		err := k8sutil.ReconcileNamespaceLabelsIgnoreNotFound(log, r.Client, ns, autoInjectLabels, nil, revisionedAutoInjectionLabelKey)
 		if err != nil {
 			log.Error(err, "failed to label namespace", "namespace", ns)
 		}
@@ -65,7 +66,7 @@ func (r *Reconciler) reconcileAutoInjectionLabels(log logr.Logger) error {
 			err := k8sutil.ReconcileNamespaceLabelsIgnoreNotFound(log, r.Client, ns.Name, nil, []string{
 				autoInjectionLabelKey,
 				managedAutoInjectionLabelKey,
-			})
+			}, revisionedAutoInjectionLabelKey)
 			if err != nil {
 				log.Error(emperror.Wrap(err, "failed to label namespace"), "namespace", ns.Name)
 			}

--- a/pkg/resources/sidecarinjector/labels.go
+++ b/pkg/resources/sidecarinjector/labels.go
@@ -52,7 +52,7 @@ func (r *Reconciler) reconcileAutoInjectionLabels(log logr.Logger) error {
 	selector := managedAutoInjectionLabelKey + "=" + autoInjectLabels[managedAutoInjectionLabelKey]
 	err := o.SetLabelSelector(selector)
 	if err != nil {
-		return emperror.WrapWith(err, "could set label selector to list options", "selector", selector)
+		return emperror.WrapWith(err, "could not set label selector to list options", "selector", selector)
 	}
 
 	err = r.Client.List(context.Background(), o, &namespaces)


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

Cherry pick of #521.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Otherwise when the operator might reconcile back the `istio-injection` label, which is not intended.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Logging code meets the guideline
