### PR TITLE
add REVISION env variable to MeshGateway deployment

### DIFF
--- a/pkg/resources/gateways/deployment.go
+++ b/pkg/resources/gateways/deployment.go
@@ -275,6 +275,11 @@ func (r *Reconciler) envVars() []apiv1.EnvVar {
 		})
 	}
 
+	envVars = append(envVars, apiv1.EnvVar{
+		Name:  "ISTIO_META_REVISION",
+		Value: r.Config.NamespacedRevision(),
+	})
+
 	envVars = k8sutil.MergeEnvVars(envVars, r.gw.Spec.AdditionalEnvVars)
 
 	return envVars


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add missing `REVISION` env variable to `MeshGateway` deployment.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Without this env variable the metadata exchange and stats envoy filters aren't applied to gateways.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
