### PR TITLE
Ensure correct binary tool dependencies

### DIFF
--- a/scripts/download-deps.sh
+++ b/scripts/download-deps.sh
@@ -5,25 +5,32 @@ set -euo pipefail
 code_generator_version=0.0.0-20180823001027-3dcf91f64f63
 controller_gen_version=0.1.9
 
-dirname=$(dirname "$0")
-binpath=$PWD/$dirname/../bin
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+binpath=${script_dir}/../bin
 
 function ensure-binary-version() {
     local bin_name=$1
     local bin_version=$2
     local download_location=$3
 
-    local target_name=${bin_name}-${bin_version}
+    local target_name=${bin_name}-proper-${bin_version}
     local link_path=${binpath}/${bin_name}
 
-    [ -e "${link_path}" ] && rm "${link_path}"
-
-    if [ ! -e "${binpath}/${target_name}" ]; then
-        GOBIN=$binpath go get "${download_location}"
-        mv "${binpath}/${bin_name}" "${binpath}/${target_name}"
+    if [ ! -L "${link_path}" ]; then
+        rm -f "${link_path}"
     fi
 
-    ln -s "${target_name}" "${link_path}"
+    if [ ! -e "${binpath}/${target_name}" ]; then
+        BUILD_DIR=$(mktemp -d)
+        pushd "${BUILD_DIR}"
+        go mod init foobar
+        GOBIN=${PWD} go get "${download_location}"
+        mv "${bin_name}" "${binpath}/${target_name}"
+        popd
+        rm -rf "${BUILD_DIR}"
+    fi
+
+    ln -sf "${target_name}" "${link_path}"
 }
 
 # code generators


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
This PR ensures that the binary tools are built using the correct dependencies

### Why?
Running go get in the istio-operator module uses the existing go.mod
and go.sum to build the binary tool. So, the resulting binary depends
on which istio-operator commit it was built on, even though the
binary tool version is properly tracked.

This commit fixes the issue by always running the `go get` command
in a pristine go module, so the resulting binary should only depend
on the contents of the binary tool repo.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
