### PR TITLE
Sync istio.io/rev auto injection namespace label between clusters

### DIFF
--- a/pkg/remoteclusters/reconcile_injection_labels.go
+++ b/pkg/remoteclusters/reconcile_injection_labels.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2020 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remoteclusters
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	istiov1beta1 "github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
+	"github.com/banzaicloud/istio-operator/pkg/util"
+)
+
+func (c *Cluster) reconcileNamespaceInjectionLabels(remoteConfig *istiov1beta1.RemoteIstio, istio *istiov1beta1.Istio) error {
+	localNamespaces := make(map[string]bool, 0)
+	namespaces := &corev1.NamespaceList{}
+	// local -> remote
+	err := c.cl.List(context.Background(), namespaces, client.MatchingLabels(istio.RevisionLabels()))
+	if err != nil {
+		return err
+	}
+
+	for _, ns := range namespaces.Items {
+		err = c.reconcileNamespaceInjectionLabel(ns.Name, istio.RevisionLabels())
+		if err != nil {
+			return err
+		}
+		localNamespaces[ns.Name] = true
+	}
+
+	remoteNamespaces := &corev1.NamespaceList{}
+	// remote -> local
+	c.ctrlRuntimeClient.List(context.Background(), remoteNamespaces, client.MatchingLabels(istio.RevisionLabels()))
+	if err != nil {
+		return err
+	}
+	for _, ns := range remoteNamespaces.Items {
+		if localNamespaces[ns.Name] {
+			continue
+		}
+		ns.Labels = util.ReduceMapByMap(ns.Labels, istio.RevisionLabels())
+		err = c.ctrlRuntimeClient.Update(context.Background(), &ns)
+		if err != nil {
+			return err
+		}
+		c.log.V(1).Info("injection label removed", "namespace", ns.Name, "labels", istio.RevisionLabels())
+	}
+
+	return nil
+}
+
+func (c *Cluster) reconcileNamespaceInjectionLabel(name string, matchingLabels map[string]string) error {
+	ns := &corev1.Namespace{}
+
+	// get namespace
+	err := c.ctrlRuntimeClient.Get(context.Background(), client.ObjectKey{
+		Name: name,
+	}, ns)
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// check if the labels already set
+	if labels.SelectorFromValidatedSet(matchingLabels).Matches(labels.Set(ns.GetLabels())) {
+		c.log.V(1).Info("injection label already matches", "namespace", ns.Name, "labels", matchingLabels)
+		return nil
+	}
+
+	// update labels
+	ns.Labels = util.MergeStringMaps(ns.Labels, matchingLabels)
+	err = c.ctrlRuntimeClient.Update(context.Background(), ns)
+	if err != nil {
+		return err
+	}
+
+	c.log.V(1).Info("injection label updated", "namespace", ns.Name, "labels", matchingLabels)
+
+	return nil
+}

--- a/pkg/resources/sidecarinjector/labels.go
+++ b/pkg/resources/sidecarinjector/labels.go
@@ -22,21 +22,43 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/goph/emperror"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
 const (
-	managedAutoInjectionLabelKey    = "istio-operator-managed-injection"
-	autoInjectionLabelKey           = "istio-injection"
-	revisionedAutoInjectionLabelKey = "istio.io/rev"
+	managedAutoInjectionLabelKey = "istio-operator-managed-injection"
 )
 
 func (r *Reconciler) reconcileAutoInjectionLabels(log logr.Logger) error {
+	namespaces := &corev1.NamespaceList{}
+	err := r.Client.List(context.Background(), namespaces, client.MatchingLabels(r.Config.RevisionLabels()))
+	if err != nil {
+		return err
+	}
+
+	for _, ns := range namespaces.Items {
+		// remove legacy injection label if set
+		if labels.SelectorFromValidatedSet(r.Config.LegacyInjectionLabels()).Matches(labels.Set(ns.GetLabels())) {
+			ns.Labels = util.ReduceMapByMap(ns.Labels, r.Config.LegacyInjectionLabels())
+			err := r.Client.Update(context.Background(), &ns)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *Reconciler) reconcileLegacyAutoInjectionLabels(log logr.Logger) error {
 	var autoInjectLabels = map[string]string{
-		autoInjectionLabelKey:        "enabled",
-		managedAutoInjectionLabelKey: "enabled",
+		v1beta1.LegacyAutoInjectionLabelKey: "enabled",
+		managedAutoInjectionLabelKey:        "enabled",
 	}
 
 	// this feature is only available for a global control plane
@@ -47,7 +69,7 @@ func (r *Reconciler) reconcileAutoInjectionLabels(log logr.Logger) error {
 	managedNamespaces := make(map[string]bool)
 	for _, ns := range r.Config.Spec.AutoInjectionNamespaces {
 		managedNamespaces[ns] = true
-		err := k8sutil.ReconcileNamespaceLabelsIgnoreNotFound(log, r.Client, ns, autoInjectLabels, nil, revisionedAutoInjectionLabelKey)
+		err := k8sutil.ReconcileNamespaceLabelsIgnoreNotFound(log, r.Client, ns, autoInjectLabels, nil, v1beta1.RevisionedAutoInjectionLabelKey)
 		if err != nil {
 			log.Error(err, "failed to label namespace", "namespace", ns)
 		}
@@ -64,9 +86,9 @@ func (r *Reconciler) reconcileAutoInjectionLabels(log logr.Logger) error {
 	for _, ns := range namespaces.Items {
 		if !managedNamespaces[ns.Name] {
 			err := k8sutil.ReconcileNamespaceLabelsIgnoreNotFound(log, r.Client, ns.Name, nil, []string{
-				autoInjectionLabelKey,
+				v1beta1.LegacyAutoInjectionLabelKey,
 				managedAutoInjectionLabelKey,
-			}, revisionedAutoInjectionLabelKey)
+			}, v1beta1.RevisionedAutoInjectionLabelKey)
 			if err != nil {
 				log.Error(emperror.Wrap(err, "failed to label namespace"), "namespace", ns.Name)
 			}

--- a/pkg/resources/sidecarinjector/labels.go
+++ b/pkg/resources/sidecarinjector/labels.go
@@ -39,6 +39,11 @@ func (r *Reconciler) reconcileAutoInjectionLabels(log logr.Logger) error {
 		managedAutoInjectionLabelKey: "enabled",
 	}
 
+	// this feature is only available for a global control plane
+	if r.Config.IsRevisionUsed() {
+		return nil
+	}
+
 	managedNamespaces := make(map[string]bool)
 	for _, ns := range r.Config.Spec.AutoInjectionNamespaces {
 		managedNamespaces[ns] = true

--- a/pkg/resources/sidecarinjector/sidecarinjector.go
+++ b/pkg/resources/sidecarinjector/sidecarinjector.go
@@ -99,10 +99,15 @@ func (r *Reconciler) Reconcile(log logr.Logger) error {
 	}
 
 	if util.PointerToBool(r.Config.Spec.SidecarInjector.Enabled) || util.PointerToBool(r.Config.Spec.Istiod.Enabled) {
-		err := r.reconcileAutoInjectionLabels(log)
+		err := r.reconcileLegacyAutoInjectionLabels(log)
 		if err != nil {
 			return emperror.WrapWith(err, "failed to label namespaces")
 		}
+	}
+
+	err := r.reconcileAutoInjectionLabels(log)
+	if err != nil {
+		return emperror.WrapWith(err, "failed to label namespaces")
 	}
 
 	log.Info("Reconciled")

--- a/pkg/resources/sidecarinjector/webhook.go
+++ b/pkg/resources/sidecarinjector/webhook.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
 	"github.com/banzaicloud/istio-operator/pkg/resources/istiod"
 	"github.com/banzaicloud/istio-operator/pkg/resources/templates"
 	"github.com/banzaicloud/istio-operator/pkg/util"
@@ -37,7 +38,7 @@ func (r *Reconciler) webhook() runtime.Object {
 
 	globalMatchExpression := []metav1.LabelSelectorRequirement{
 		{
-			Key:      "istio-injection",
+			Key:      v1beta1.LegacyAutoInjectionLabelKey,
 			Operator: metav1.LabelSelectorOpIn,
 			Values:   []string{"enabled"},
 		},
@@ -50,7 +51,7 @@ func (r *Reconciler) webhook() runtime.Object {
 			Values:   []string{r.Config.Namespace},
 		},
 		{
-			Key:      "istio-injection",
+			Key:      v1beta1.LegacyAutoInjectionLabelKey,
 			Operator: metav1.LabelSelectorOpNotIn,
 			Values:   []string{"disabled"},
 		},
@@ -62,18 +63,18 @@ func (r *Reconciler) webhook() runtime.Object {
 			Operator: metav1.LabelSelectorOpDoesNotExist,
 		},
 		{
-			Key:      "istio.io/rev",
+			Key:      v1beta1.RevisionedAutoInjectionLabelKey,
 			Operator: metav1.LabelSelectorOpDoesNotExist,
 		},
 	}
 
 	revisionLabelMatchExpression := []metav1.LabelSelectorRequirement{
 		{
-			Key:      "istio-injection",
+			Key:      v1beta1.LegacyAutoInjectionLabelKey,
 			Operator: metav1.LabelSelectorOpDoesNotExist,
 		},
 		{
-			Key:      "istio.io/rev",
+			Key:      v1beta1.RevisionedAutoInjectionLabelKey,
 			Operator: metav1.LabelSelectorOpIn,
 			Values: []string{
 				r.Config.NamespacedRevision(),

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -123,6 +123,23 @@ func RemoveString(slice []string, s string) (result []string) {
 	return
 }
 
+func ReduceMapByMap(original map[string]string, reduce map[string]string) map[string]string {
+	final := make(map[string]string)
+	slice := make(map[string]bool, 0)
+	for k := range reduce {
+		slice[k] = true
+	}
+
+	for k, v := range original {
+		if slice[k] {
+			continue
+		}
+		final[k] = v
+	}
+
+	return final
+}
+
 func GetPodSecurityContextFromSecurityContext(sc *corev1.SecurityContext) *corev1.PodSecurityContext {
 	if sc == nil || *sc == (corev1.SecurityContext{}) {
 		return &corev1.PodSecurityContext{}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | https://banzaicloud.atlassian.net/browse/BY-152
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Adds `istio.io/rev` auto injection namespace label synchronization between clusters participating in a single mesh.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In a single mesh multi cluster environment, each particular namespace in every participant clusters considered the same, thus the injection namespace label must be synchronized.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
