### PR TITLE
Fix missing quotation mark in EnvoyFilter

### DIFF
--- a/pkg/resources/ingressgateway/multimesh.go
+++ b/pkg/resources/ingressgateway/multimesh.go
@@ -94,7 +94,7 @@ func (r *Reconciler) multimeshEnvoyFilter() *k8sutil.DynamicObject {
 						"value": map[string]interface{}{
 							"name": "envoy.filters.network.tcp_cluster_rewrite",
 							"typed_config": map[string]interface{}{
-								"@type":               "type.googleapis.com/istio.envoy.config.filter.network.tcp_cluster_rewrite.v2alpha1.TcpClusterRewrite",
+								"\"@type\"":           "type.googleapis.com/istio.envoy.config.filter.network.tcp_cluster_rewrite.v2alpha1.TcpClusterRewrite",
 								"cluster_pattern":     fmt.Sprintf("\\.%s$", util.PointerToString(r.Config.Spec.GlobalDomain)),
 								"cluster_replacement": ".svc." + r.Config.Spec.Proxy.ClusterDomain,
 							},


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

`"@type"` should be used in the EnvoyFilter syntax **with** quotation marks.
