### PR TITLE
BY-591: Upgrade kube-rbac-proxy to v0.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,12 @@
 version: 2.1
 orbs:
-  helm: banzaicloud/helm@0.0.3
+  helm: banzaicloud/helm@0.0.8
   docker: banzaicloud/docker@0.0.5
+
+executors:
+  helm311:
+    docker:
+      - image: ghcr.io/banzaicloud/helm:0.0.7
 
 commands:
   publish-with-latests:
@@ -152,14 +157,16 @@ workflows:
   helm-chart:
     jobs:
       - helm/lint-chart:
-          chart-path: deploy/charts/istio-operator
+          executor: helm311
+          charts-dir: deploy/charts
           filters:
             tags:
               ignore: /.*/
 
       - helm/publish-chart:
           context: helm
-          chart-path: deploy/charts/istio-operator
+          executor: helm311
+          charts-dir: deploy/charts
           filters:
             branches:
               ignore: /.*/

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,5 @@ indent_style = tab
 [{Makefile,*.mk}]
 indent_style = tab
 
-[*.yaml]
+[{*.yaml,*.yml}]
 indent_size = 2

--- a/config/overlays/auth-proxy-enabled/manager_auth_proxy_patch.yaml
+++ b/config/overlays/auth-proxy-enabled/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/deploy/charts/istio-operator/README.md
+++ b/deploy/charts/istio-operator/README.md
@@ -39,7 +39,7 @@ Parameter | Description | Default
 `prometheusMetrics.enabled` | If true, use direct access for Prometheus metrics | `false`
 `prometheusMetrics.authProxy.enabled` | If true, use auth proxy for Prometheus metrics | `true`
 `prometheusMetrics.authProxy.image.repository` | Auth proxy container image repository | `gcr.io/kubebuilder/kube-rbac-proxy`
-`prometheusMetrics.authProxy.image.tag` | Auth proxy container image tag | `v0.4.0`
+`prometheusMetrics.authProxy.image.tag` | Auth proxy container image tag | `v0.5.0`
 `prometheusMetrics.authProxy.image.pullPolicy` | Auth proxy container image pull policy | `IfNotPresent`
 `rbac.enabled` | Create rbac service account and roles | `true`
 `rbac.psp.enabled` | Create pod security policy and binding | `false`

--- a/deploy/charts/istio-operator/values.yaml
+++ b/deploy/charts/istio-operator/values.yaml
@@ -23,7 +23,7 @@ prometheusMetrics:
     enabled: true
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.4.0
+      tag: v0.5.0
       pullPolicy: IfNotPresent
 
 ## Role Based Access


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | BY-591
| License         | Apache 2.0


### What's in this PR?

Upgrade of the kube-rbac-proxy docker image to v0.5.0.

It also contains a fix for publishing the helm chart.


### Why?

To fix the security vulnerabilities reported by anchore.


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide)
- [x] User guide and development docs updated (if needed)
- [x] Related Helm chart(s) updated (if needed)

### To Do

- [x] Needs testing
