### PR TITLE
fix imps injection configmap

### DIFF
--- a/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
+++ b/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
@@ -69,12 +69,17 @@ func (r *Reconciler) getValues() string {
 				"enabled":          util.PointerToBool(r.Config.Spec.Istiod.Enabled),
 				"caRootConfigName": r.Config.WithRevisionIf("istio-ca-root-cert", util.PointerToBool(r.Config.Spec.Istiod.MultiControlPlaneSupport)),
 			},
-			"caAddress":              r.Config.GetCAAddress(),
-			"jwtPolicy":              r.Config.Spec.JWTPolicy,
-			"pilotCertProvider":      r.Config.Spec.Pilot.CertProvider,
-			"trustDomain":            r.Config.Spec.TrustDomain,
-			"imagePullPolicy":        r.Config.Spec.ImagePullPolicy,
-			"imagePullSecrets":       r.Config.Spec.ImagePullSecrets,
+			"caAddress":         r.Config.GetCAAddress(),
+			"jwtPolicy":         r.Config.Spec.JWTPolicy,
+			"pilotCertProvider": r.Config.Spec.Pilot.CertProvider,
+			"trustDomain":       r.Config.Spec.TrustDomain,
+			"imagePullPolicy":   r.Config.Spec.ImagePullPolicy,
+			"imagePullSecrets": func() (names []string) {
+				for _, name := range r.Config.Spec.ImagePullSecrets {
+					names = append(names, name.Name)
+				}
+				return names
+			}(),
 			"network":                r.Config.Spec.NetworkName,
 			"podDNSSearchNamespaces": podDNSSearchNamespaces,
 			"proxy_init": map[string]interface{}{
@@ -553,7 +558,7 @@ volumes:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets:
   {{- range .Values.global.imagePullSecrets }}
-  - name: {{ .name }}
+  - name: {{ . }}
   {{- end }}
 {{- end }}
 podRedirectAnnot:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fix unmarshalling issue with the `imagePullSecrets` value in the istio injection configmap.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

That property is defined as `[]string` at the istio side, it needs to be prepared accordingly.
