### PR TITLE
Remove unused sidecar injector config field

### DIFF
--- a/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
+++ b/pkg/resources/sidecarinjector/configmap_sidecar_injector.go
@@ -145,8 +145,7 @@ func (r *Reconciler) siConfig() string {
 		autoInjection = "enabled"
 	}
 	siConfig := map[string]interface{}{
-		"policy":   autoInjection,
-		"template": r.templateConfig(),
+		"policy": autoInjection,
 
 		"defaultTemplates": []string{"sidecar"},
 		"templates":        r.templates(),
@@ -605,39 +604,6 @@ imagePullSecrets:
 securityContext:
   fsGroup: 1337
 {{- end }}
-`
-}
-
-func (r *Reconciler) templateConfig() string {
-	return `rewriteAppHTTPProbe: {{ valueOrDefault .Values.sidecarInjectorWebhook.rewriteAppHTTPProbe true }}
-{{- if .Values.global.podDNSSearchNamespaces }}
-dnsConfig:
-  searches:
-    {{- range .Values.global.podDNSSearchNamespaces }}
-    - {{ render . }}
-    {{- end }}
-{{- end }}
-httpProxyEnvs:
-  httpProxy: {{ .Values.sidecarInjectorWebhook.httpProxyEnvs.httpProxy }}
-  httpsProxy: {{ .Values.sidecarInjectorWebhook.httpProxyEnvs.httpsProxy }}
-  noProxy: {{ .Values.sidecarInjectorWebhook.httpProxyEnvs.noProxy }}
-` + r.templatePodSpec(0) + `
-podRedirectAnnot:
-{{- if and (.Values.global.proxy_init.cniEnabled) (not .Values.global.proxy_init.cniChained) }}
-k8s.v1.cni.cncf.io/networks: '{{ appendMultusNetwork (index .ObjectMeta.Annotations ` + "`" + `k8s.v1.cni.cncf.io/networks` + "`" + `) ` + "`" + `istio-cni` + "`" + ` }}'
-{{- end }}
-   sidecar.istio.io/interceptionMode: "{{ annotation .ObjectMeta ` + "`" + `sidecar.istio.io/interceptionMode` + "`" + ` .ProxyConfig.InterceptionMode }}"
-   traffic.sidecar.istio.io/includeOutboundIPRanges: "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/includeOutboundIPRanges` + "`" + ` .Values.global.proxy.includeIPRanges }}"
-   traffic.sidecar.istio.io/excludeOutboundIPRanges: "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/excludeOutboundIPRanges` + "`" + ` .Values.global.proxy.excludeIPRanges }}"
-   traffic.sidecar.istio.io/includeInboundPorts: "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/includeInboundPorts` + "`" + ` (includeInboundPorts .Spec.Containers) }}"
-   traffic.sidecar.istio.io/excludeInboundPorts: "{{ excludeInboundPort (annotation .ObjectMeta ` + "`" + `status.sidecar.istio.io/port` + "`" + ` .Values.global.proxy.statusPort) (annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/excludeInboundPorts` + "`" + ` .Values.global.proxy.excludeInboundPorts) }}"
-{{ if or (isset .ObjectMeta.Annotations  ` + "`" + `traffic.sidecar.istio.io/includeOutboundPorts ` + "`" + `) (ne (valueOrDefault .Values.global.proxy.includeOutboundPorts "") "") }}
-    traffic.sidecar.istio.io/includeOutboundPorts: "{{ annotation .ObjectMeta  ` + "`" + `traffic.sidecar.istio.io/includeOutboundPorts ` + "`" + ` .Values.global.proxy.includeOutboundPorts }}"
-{{- end }}
-{{ if or (isset .ObjectMeta.Annotations ` + "`" + `traffic.sidecar.istio.io/excludeOutboundPorts` + "`" + `) (ne .Values.global.proxy.excludeOutboundPorts "") }}
-   traffic.sidecar.istio.io/excludeOutboundPorts: "{{ annotation .ObjectMeta ` + "`" + `traffic.sidecar.istio.io/excludeOutboundPorts` + "`" + ` .Values.global.proxy.excludeOutboundPorts }}"
-{{- end }}
-   traffic.sidecar.istio.io/kubevirtInterfaces: "{{ index .ObjectMeta.Annotations ` + "`" + `traffic.sidecar.istio.io/kubevirtInterfaces` + "`" + ` }}"
 `
 }
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?

Remove template field from sidecar injector configmap.


### Why?

The "template" field is superseded by the "templates" field, so
"template" shouldn't be used anymore.

Originally, it was an error to have both `template` and `templates` set:
https://github.com/istio/istio/commit/772d1d310a56a913ec218359418d6eb0719a2776#diff-3658c8df7815d0014a39c664de6ee52d83c4e85d6f57d2eadfc829c008e87bf1R151

This error has since been removed, and `template` is simply ignored:
https://github.com/istio/istio/blob/57be1f80738062e72dd42e9f246b4a74e4027bd8/pkg/kube/inject/inject.go#L141


### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
