### PR TITLE
fix automatic service port mutation

### DIFF
--- a/pkg/resources/gateways/service_test.go
+++ b/pkg/resources/gateways/service_test.go
@@ -221,3 +221,29 @@ func TestEnsureStatusPort_PortNameAndTargetPort(t *testing.T) {
 	}
 	require.Equal(t, expectedPorts, ports)
 }
+
+func TestEnsurePort_MissingProtocol(t *testing.T) {
+	originalPorts := []apiv1.ServicePort{
+		{
+			Name:       "http",
+			Port:       80,
+			TargetPort: intstr.FromInt(8080),
+		},
+	}
+	ports := ensureStatusPort(append([]apiv1.ServicePort{}, originalPorts...))
+
+	expectedPorts := []apiv1.ServicePort{
+		{
+			Name:       "status-port",
+			Protocol:   "TCP",
+			Port:       istiov1beta1.PortStatusPortNumber,
+			TargetPort: intstr.FromInt(15021),
+		},
+		{
+			Name:       "http",
+			Port:       80,
+			TargetPort: intstr.FromInt(8080),
+		},
+	}
+	require.Equal(t, expectedPorts, ports)
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixes a bug with ports without specified protocols during service port mutation.
