### PR TITLE
[1.9] fix runAsRoot security context

### DIFF
--- a/pkg/apis/istio/v1beta1/meshgateway_defaults.go
+++ b/pkg/apis/istio/v1beta1/meshgateway_defaults.go
@@ -47,8 +47,9 @@ func (c *MeshGatewayConfiguration) SetDefaults() {
 	if c.SecurityContext == nil {
 		if util.PointerToBool(c.RunAsRoot) {
 			c.SecurityContext = &apiv1.SecurityContext{
-				RunAsUser:  util.Int64Pointer(0),
-				RunAsGroup: util.Int64Pointer(0),
+				RunAsUser:    util.Int64Pointer(0),
+				RunAsGroup:   util.Int64Pointer(0),
+				RunAsNonRoot: util.BoolPointer(false),
 			}
 		} else {
 			c.SecurityContext = defaultSecurityContext

--- a/pkg/apis/istio/v1beta1/meshgateway_defaults.go
+++ b/pkg/apis/istio/v1beta1/meshgateway_defaults.go
@@ -46,7 +46,10 @@ func (c *MeshGatewayConfiguration) SetDefaults() {
 	}
 	if c.SecurityContext == nil {
 		if util.PointerToBool(c.RunAsRoot) {
-			c.SecurityContext = &apiv1.SecurityContext{}
+			c.SecurityContext = &apiv1.SecurityContext{
+				RunAsUser:  util.Int64Pointer(0),
+				RunAsGroup: util.Int64Pointer(0),
+			}
 		} else {
 			c.SecurityContext = defaultSecurityContext
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixes security context for mesh gateways with `runAsRoot` enabled.
