### PR TITLE
[1.8] Fix updating unrelated RemoteIstio resource

### DIFF
--- a/pkg/controller/remoteistio/remoteistio_controller.go
+++ b/pkg/controller/remoteistio/remoteistio_controller.go
@@ -175,6 +175,22 @@ func (r *ReconcileRemoteConfig) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, nil
 	}
 
+	istio, err := r.getRelatedIstioCR(remoteConfig)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	istio.SetDefaults()
+
+	if !istio.Spec.Version.IsSupported() {
+		if istio.Status.Status == istiov1beta1.Created || istio.Status.Status == istiov1beta1.Unmanaged {
+			err = errors.New("intended Istio version is unsupported by this version of the operator")
+			logger.Error(err, "", "version", istio.Spec.Version)
+		}
+		return reconcile.Result{
+			Requeue: false,
+		}, nil
+	}
+
 	if remoteConfig.ObjectMeta.DeletionTimestamp.IsZero() {
 		if !util.ContainsString(remoteConfig.ObjectMeta.Finalizers, finalizerID) {
 			remoteConfig.ObjectMeta.Finalizers = append(remoteConfig.ObjectMeta.Finalizers, finalizerID)
@@ -223,22 +239,6 @@ func (r *ReconcileRemoteConfig) Reconcile(request reconcile.Request) (reconcile.
 		logger.Info("remote istio removed")
 
 		return reconcile.Result{}, nil
-	}
-
-	istio, err := r.getRelatedIstioCR(remoteConfig)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	istio.SetDefaults()
-
-	if !istio.Spec.Version.IsSupported() {
-		if istio.Status.Status == istiov1beta1.Created || istio.Status.Status == istiov1beta1.Unmanaged {
-			err = errors.New("intended Istio version is unsupported by this version of the operator")
-			logger.Error(err, "", "version", istio.Spec.Version)
-		}
-		return reconcile.Result{
-			Requeue: false,
-		}, nil
 	}
 
 	remoteConfig.Spec.IstioControlPlane = &istiov1beta1.NamespacedName{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixes a bug around updating unrelated `RemoteIstio` resource.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In case of missing finalizers non-related `RemoteIstio` resource was updated which caused unwanted side-effects with newly created resource properties.
