### PR TITLE
[1.6] add workaround to set validating webhook sideeffects to none

### DIFF
--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -44,7 +44,12 @@ func add(mgr manager.Manager) error {
 		return errors.Errorf("%s env variable must be specified and cannot be empty", podNamespaceEnvVar)
 	}
 
-	svr, err := webhook.NewServer(name, mgr, webhook.ServerOptions{
+	svr, err := webhook.NewServer(name, &ManagerWithCustomClient{
+		Manager: mgr,
+		client: &WebhookUpdateClient{
+			Client: mgr.GetClient(),
+		},
+	}, webhook.ServerOptions{
 		Port:    9443,
 		CertDir: "/tmp/cert",
 		BootstrapOptions: &webhook.BootstrapOptions{

--- a/pkg/webhook/server/webhook_manager.go
+++ b/pkg/webhook/server/webhook_manager.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+// ManagerWithCustomClient is able to inject custom client into a runnable
+type ManagerWithCustomClient struct {
+	manager.Manager
+	client client.Client
+}
+
+func (m *ManagerWithCustomClient) Add(r manager.Runnable) error {
+	err := m.Manager.Add(r)
+	if err != nil {
+		return err
+	}
+
+	// override client in the runnable to handle webhook update
+	if _, err := inject.ClientInto(m.client, r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WebhookUpdateClient is a specific runtime client that modifies validating webhook sideeffect property
+type WebhookUpdateClient struct {
+	client.Client
+}
+
+func (w *WebhookUpdateClient) Update(ctx context.Context, obj runtime.Object) error {
+	se := admissionregistrationv1beta1.SideEffectClassNone
+	if o, ok := obj.(*admissionregistrationv1beta1.ValidatingWebhookConfiguration); ok {
+		for i := range o.Webhooks {
+			o.Webhooks[i].SideEffects = &se
+		}
+	}
+
+	return w.Client.Update(ctx, obj)
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #445
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Adds a workaround to set the generated validating webhook side effects to `None`.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Unfortunately there is no way to easily configure the webhook builder to set the side effects property.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
