### PR TITLE
Add notice on license ownership change

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,14 @@
+Copyright © 2019 Banzai Cloud
+Copyright © 2021 Cisco Systems, Inc. and/or its affiliates
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
As Banzai Cloud is acquired by Cisco Systems, we are transferring the Copyrights to Cisco.