### PR TITLE
[1.9] add cluster name as env var to Istio deployment

### DIFF
--- a/pkg/resources/istiod/deployment.go
+++ b/pkg/resources/istiod/deployment.go
@@ -120,6 +120,10 @@ func (r *Reconciler) containerEnvs() []apiv1.EnvVar {
 			Name:  "PILOT_ENABLE_STATUS",
 			Value: strconv.FormatBool(util.PointerToBool(r.Config.Spec.Istiod.EnableStatus)),
 		},
+		{
+			Name:  "CLUSTER_ID",
+			Value: r.Config.Spec.ClusterName,
+		},
 	}
 
 	enablePilotEndpointTelemetry := false


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- add cluster name as env var to Istio deployment

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

CLUSTER_ID env var is used the specify the name of the cluster within Istiod.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Cluster name is used for the service registry and for the remote side proxy authentication as well.
