### PR TITLE
[1.8] add cluster name as env var to Istiod deployment

### DIFF
--- a/pkg/resources/istiod/deployment.go
+++ b/pkg/resources/istiod/deployment.go
@@ -120,6 +120,10 @@ func (r *Reconciler) containerEnvs() []apiv1.EnvVar {
 			Name:  "PILOT_ENABLE_STATUS",
 			Value: strconv.FormatBool(util.PointerToBool(r.Config.Spec.Istiod.EnableStatus)),
 		},
+		{
+			Name:  "CLUSTER_ID",
+			Value: r.Config.Spec.ClusterName,
+		},
 	}
 
 	if util.PointerToBool(r.Config.Spec.Istiod.MultiControlPlaneSupport) {


### PR DESCRIPTION
Same as #621, just for v1.8
