### PR TITLE
Pull Istio images from GCR

### DIFF
--- a/config/samples/istio_v1beta1_istio.yaml
+++ b/config/samples/istio_v1beta1_istio.yaml
@@ -28,7 +28,7 @@ spec:
       enabled: false
   pilot:
     enabled: true
-    image: "docker.io/istio/pilot:1.9.3"
+    image: "gcr.io/istio-release/pilot:1.9.3"
     replicaCount: 1
     minReplicas: 1
     maxReplicas: 5
@@ -104,7 +104,7 @@ spec:
   telemetry:
     enabled: false
   proxy:
-    image: "docker.io/istio/proxyv2:1.9.3"
+    image: "gcr.io/istio-release/proxyv2:1.9.3"
     accessLogFile: "/dev/stdout"
     accessLogFormat: ""
     accessLogEncoding: "TEXT"
@@ -118,7 +118,7 @@ spec:
         cpu: 2000m
         memory: 1024Mi
   proxyInit:
-    image: "docker.io/istio/proxyv2:1.9.3"
+    image: "gcr.io/istio-release/proxyv2:1.9.3"
   defaultPodDisruptionBudget:
     enabled: true
   outboundTrafficPolicy:

--- a/config/samples/istio_v1beta1_istio.yaml
+++ b/config/samples/istio_v1beta1_istio.yaml
@@ -101,16 +101,8 @@ spec:
       enabled: false
   policy:
     enabled: false
-    image: "docker.io/istio/mixer:1.9.3"
-    replicaCount: 1
-    minReplicas: 1
-    maxReplicas: 5
   telemetry:
     enabled: false
-    image: "docker.io/istio/mixer:1.9.3"
-    replicaCount: 1
-    minReplicas: 1
-    maxReplicas: 5
   proxy:
     image: "docker.io/istio/proxyv2:1.9.3"
     accessLogFile: "/dev/stdout"

--- a/config/samples/istio_v1beta1_istio_cni.yaml
+++ b/config/samples/istio_v1beta1_istio_cni.yaml
@@ -26,5 +26,5 @@ spec:
         brokenPodLabelKey: "cni.istio.io/uninitialized"
         brokenPodLabelValue: "true"
   proxy:
-    image: "docker.io/istio/proxyv2:1.9.3"
+    image: "gcr.io/istio-release/proxyv2:1.9.3"
   jwtPolicy: "first-party-jwt"

--- a/config/samples/istio_v1beta1_istio_cni_gke.yaml
+++ b/config/samples/istio_v1beta1_istio_cni_gke.yaml
@@ -27,5 +27,5 @@ spec:
         brokenPodLabelKey: "cni.istio.io/uninitialized"
         brokenPodLabelValue: "true"
   proxy:
-    image: "docker.io/istio/proxyv2:1.9.3"
+    image: "gcr.io/istio-release/proxyv2:1.9.3"
   jwtPolicy: "first-party-jwt"

--- a/config/samples/istio_v1beta1_istio_meshexpansion.yaml
+++ b/config/samples/istio_v1beta1_istio_meshexpansion.yaml
@@ -11,5 +11,5 @@ spec:
     mtlsMode: STRICT
   meshExpansion: true
   proxy:
-    image: "docker.io/istio/proxyv2:1.9.3"
+    image: "gcr.io/istio-release/proxyv2:1.9.3"
   jwtPolicy: "first-party-jwt"

--- a/config/samples/istio_v1beta1_istio_minimal.yaml
+++ b/config/samples/istio_v1beta1_istio_minimal.yaml
@@ -29,5 +29,5 @@ spec:
   tracing:
     enabled: false
   proxy:
-    image: "docker.io/istio/proxyv2:1.9.3"
+    image: "gcr.io/istio-release/proxyv2:1.9.3"
   jwtPolicy: "first-party-jwt"

--- a/config/samples/istio_v1beta1_istio_multimesh.yaml
+++ b/config/samples/istio_v1beta1_istio_multimesh.yaml
@@ -15,5 +15,5 @@ spec:
   citadel:
     caSecretName: "cacerts"
   proxy:
-    image: "docker.io/istio/proxyv2:1.9.3"
+    image: "gcr.io/istio-release/proxyv2:1.9.3"
   jwtPolicy: "first-party-jwt"

--- a/docs/upgrade/in-place-upgrade.md
+++ b/docs/upgrade/in-place-upgrade.md
@@ -79,7 +79,6 @@ The `Istio` Custom Resource is showing `Available` in its status field and the I
 $ kubectl get -n istio-system istio -o yaml | grep "image:"
     image: docker.io/istio/citadel:1.8.2
     image: docker.io/istio/galley:1.8.2
-    image: docker.io/istio-mixer:1.8.2
     image: docker.io/istio-pilot:1.8.2
     image: docker.io/istio/proxyv2:1.8.2
     image: docker.io/istio/sidecar_injector:1.8.2
@@ -181,7 +180,6 @@ $ kubectl describe istio -n istio-system istio | grep Image:
         Image:    docker.io/istio/node-agent-k8s:1.9.3
     Image:          coredns/coredns:1.9.3
     Plugin Image:   docker.io/istio/coredns-plugin:0.2-istio-1.1
-    Image:          docker.io/istio/mixer:1.9.3
     Image:    docker.io/istio/node-agent-k8s:1.9.3
     Image:          docker.io/istio/pilot:1.9.3
     Image:             docker.io/istio/proxyv2:1.9.3

--- a/docs/upgrade/in-place-upgrade.md
+++ b/docs/upgrade/in-place-upgrade.md
@@ -79,7 +79,7 @@ The `Istio` Custom Resource is showing `Available` in its status field and the I
 $ kubectl get -n istio-system istio -o yaml | grep "image:"
     image: docker.io/istio/citadel:1.8.2
     image: docker.io/istio/galley:1.8.2
-    image: docker.io/istio-pilot:1.8.2
+    image: docker.io/istio/pilot:1.8.2
     image: docker.io/istio/proxyv2:1.8.2
     image: docker.io/istio/sidecar_injector:1.8.2
 ```

--- a/pkg/apis/istio/v1beta1/defaults.go
+++ b/pkg/apis/istio/v1beta1/defaults.go
@@ -29,7 +29,7 @@ import (
 const (
 	banzaiImageHub                         = "ghcr.io/banzaicloud"
 	banzaiImageVersion                     = "1.9.3-bzc"
-	defaultImageHub                        = "docker.io/istio"
+	defaultImageHub                        = "gcr.io/istio-release"
 	defaultImageVersion                    = "1.9.3"
 	defaultLogLevel                        = "default:info"
 	defaultMeshPolicy                      = PERMISSIVE
@@ -115,13 +115,17 @@ var defaultInitResources = &apiv1.ResourceRequirements{
 	},
 }
 
-const ProxyStatusPort = 15020
-const PortStatusPortNumber = 15021
-const PortStatusPortName = "status-port"
+const (
+	ProxyStatusPort      = 15020
+	PortStatusPortNumber = 15021
+	PortStatusPortName   = "status-port"
+)
 
-var defaultIngressGatewayPorts = []ServicePort{}
-var defaultEgressGatewayPorts = []ServicePort{}
-var defaultMeshExpansionGatewayPorts = []ServicePort{}
+var (
+	defaultIngressGatewayPorts       = []ServicePort{}
+	defaultEgressGatewayPorts        = []ServicePort{}
+	defaultMeshExpansionGatewayPorts = []ServicePort{}
+)
 
 // SetDefaults used to support generic defaulter interface
 func (config *Istio) SetDefaults() {

--- a/scripts/e2e-test/setup-env.sh
+++ b/scripts/e2e-test/setup-env.sh
@@ -23,8 +23,8 @@ kind load docker-image kennethreitz/httpbin
 
 # TODO collect these from the operator (run the related functions and collect the referenced images)
 docker pull gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-docker pull docker.io/istio/pilot:"${istio_version}"
-docker pull docker.io/istio/proxyv2:"${istio_version}"
+docker pull gcr.io/istio-release/pilot:"${istio_version}"
+docker pull gcr.io/istio-release/proxyv2:"${istio_version}"
 kind load docker-image gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-kind load docker-image docker.io/istio/pilot:"${istio_version}"
-kind load docker-image docker.io/istio/proxyv2:"${istio_version}"
+kind load docker-image gcr.io/istio-release/pilot:"${istio_version}"
+kind load docker-image gcr.io/istio-release/proxyv2:"${istio_version}"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?

Pull Istio images from GCR.


### Why?

To avoid hitting rate limits instituted on Docker Hub.


### Checklist

- [x] Implementation tested

### To Do

- [x] Wait for #615 to be merged
