### PR TITLE
Workaround for cluster cleanup issue in end-to-end tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,11 +172,12 @@ e2e-test-install-istio-operator: docker-build
 		istio-operator-e2e-test \
 		deploy/charts/istio-operator/
 
-	# TODO maybe wait until all pods are up and running?
-	#  `helm --wait` only waits for the pods installed by helm. Usually, when the istio-operator is ready,
-	#  a couple of pods in kube-system are still just starting up. It works out fine now, probably because
-	#  there is a wait in TestMain for the cluster to be reachable. Waiting here for all pods might result
-	#  in a lower load on the cluster when the actual tests start, so it might remove some flakiness.
+	# Wait for all pods to be ready. `helm --wait` only waits for the pods installed by helm. Usually,
+	# when the istio-operator is ready, a couple of pods in kube-system are still just starting up. It
+	# works out fine now, probably because there is a wait in TestMain for the cluster to be reachable.
+	# Waiting here for all pods might result in a lower load on the cluster when the actual tests
+	# start, so it might remove some flakiness.
+	kubectl wait pod --all-namespaces --all --for=condition=ready
 
 .PHONY: e2e-test
 e2e-test: export PATH:=./bin:${PATH}

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ e2e-test-install-istio-operator: docker-build
 	# works out fine now, probably because there is a wait in TestMain for the cluster to be reachable.
 	# Waiting here for all pods might result in a lower load on the cluster when the actual tests
 	# start, so it might remove some flakiness.
-	kubectl wait pod --all-namespaces --all --for=condition=ready
+	kubectl wait pod --all-namespaces --all --for=condition=ready --timeout=60s
 
 .PHONY: e2e-test
 e2e-test: export PATH:=./bin:${PATH}

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,9 @@ e2e-test-dependencies:
 
 .PHONY: e2e-test-env
 e2e-test-env: e2e-test-dependencies
-	env PATH=./bin:$${PATH} ./scripts/e2e-test/setup-env.sh ${ISTIO_VERSION}
+	# There's an issue (https://github.com/banzaicloud/istio-operator/issues/643) with resource cleanup on
+	# k8s 1.20, so running the tests on 1.19.7 for now
+	env PATH=./bin:$${PATH} ./scripts/e2e-test/setup-env.sh 1.19.7 ${ISTIO_VERSION}
 
 .PHONY: e2e-test-install-istio-operator
 e2e-test-install-istio-operator: export PATH:=./bin:${PATH}

--- a/pkg/resources/citadel/mtls.go
+++ b/pkg/resources/citadel/mtls.go
@@ -17,10 +17,9 @@ limitations under the License.
 package citadel
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
@@ -46,11 +45,7 @@ func (r *Reconciler) spec() map[string]interface{} {
 // https://istio.io/docs/tasks/security/authn-policy/
 func (r *Reconciler) peerAuthentication() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "security.istio.io",
-			Version:  "v1beta1",
-			Resource: "peerauthentications",
-		},
+		Gvr:       gvr.PeerAuthentication,
 		Kind:      "PeerAuthentication",
 		Name:      r.Config.WithRevision("default"),
 		Namespace: r.Config.Namespace,
@@ -64,11 +59,7 @@ func (r *Reconciler) peerAuthentication() *k8sutil.DynamicObject {
 // any service (host) in the mesh
 func (r *Reconciler) destinationRuleDefaultMtls() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "destinationrules",
-		},
+		Gvr:       gvr.DestinationRule,
 		Kind:      "DestinationRule",
 		Name:      r.Config.WithRevision("default"),
 		Namespace: r.Config.Namespace,
@@ -89,11 +80,7 @@ func (r *Reconciler) destinationRuleDefaultMtls() *k8sutil.DynamicObject {
 // User should add similar destination rules for other services that don't have sidecar
 func (r *Reconciler) destinationRuleApiServerMtls() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "destinationrules",
-		},
+		Gvr:       gvr.DestinationRule,
 		Kind:      "DestinationRule",
 		Name:      r.Config.WithRevision("api-server"),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/egressgateway/multimesh.go
+++ b/pkg/resources/egressgateway/multimesh.go
@@ -19,9 +19,8 @@ package egressgateway
 import (
 	"fmt"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 )
 
 const (
@@ -35,11 +34,7 @@ func (r *Reconciler) multimeshEgressGateway() *k8sutil.DynamicObject {
 	}
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "gateways",
-		},
+		Gvr:       gvr.Gateway,
 		Kind:      "Gateway",
 		Name:      r.Config.WithRevision(multimeshResourceNamePrefix + "-egressgateway"),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/gvr/gvr.go
+++ b/pkg/resources/gvr/gvr.go
@@ -66,6 +66,60 @@ var MutatingWebhookConfiguration = schema.GroupVersionResource{
 	Resource: "mutatingwebhookconfigurations",
 }
 
+var DestinationRule = schema.GroupVersionResource{
+	Group:    "networking.istio.io",
+	Version:  "v1alpha3",
+	Resource: "destinationrules",
+}
+
+var VirtualService = schema.GroupVersionResource{
+	Group:    "networking.istio.io",
+	Version:  "v1alpha3",
+	Resource: "virtualservices",
+}
+
+var PeerAuthentication = schema.GroupVersionResource{
+	Group:    "security.istio.io",
+	Version:  "v1beta1",
+	Resource: "peerauthentications",
+}
+
+var Gateway = schema.GroupVersionResource{
+	Group:    "networking.istio.io",
+	Version:  "v1alpha3",
+	Resource: "gateways",
+}
+
+var EnvoyFilter = schema.GroupVersionResource{
+	Group:    "networking.istio.io",
+	Version:  "v1alpha3",
+	Resource: "envoyfilters",
+}
+
+var AttributeManifest = schema.GroupVersionResource{
+	Group:    "config.istio.io",
+	Version:  "v1alpha2",
+	Resource: "attributemanifests",
+}
+
+var IstioConfigHandler = schema.GroupVersionResource{
+	Group:    "config.istio.io",
+	Version:  "v1alpha2",
+	Resource: "handlers",
+}
+
+var IstioConfigInstance = schema.GroupVersionResource{
+	Group:    "config.istio.io",
+	Version:  "v1alpha2",
+	Resource: "instances",
+}
+
+var IstioConfigRule = schema.GroupVersionResource{
+	Group:    "config.istio.io",
+	Version:  "v1alpha2",
+	Resource: "rules",
+}
+
 var Istio = schema.GroupVersionResource{
 	Group:    "istio.banzaicloud.io",
 	Version:  "v1beta1",

--- a/pkg/resources/gvr/gvr.go
+++ b/pkg/resources/gvr/gvr.go
@@ -14,65 +14,65 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package gvr
 
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
-var serviceGVR = schema.GroupVersionResource{
+var Service = schema.GroupVersionResource{
 	Group:    "",
 	Version:  "v1",
 	Resource: "services",
 }
 
-var podGVR = schema.GroupVersionResource{
+var Pod = schema.GroupVersionResource{
 	Group:    "",
 	Version:  "v1",
 	Resource: "pods",
 }
 
-var deploymentGVR = schema.GroupVersionResource{
+var Deployment = schema.GroupVersionResource{
 	Group:    "apps",
 	Version:  "v1",
 	Resource: "deployments",
 }
 
-var horizontalPodAutoscalerGVR = schema.GroupVersionResource{
+var HorizontalPodAutoscaler = schema.GroupVersionResource{
 	Group:    "autoscaling",
 	Version:  "v1",
 	Resource: "horizontalpodautoscalers",
 }
 
-var clusterRoleGVR = schema.GroupVersionResource{
+var ClusterRole = schema.GroupVersionResource{
 	Group:    "rbac.authorization.k8s.io",
 	Version:  "v1",
 	Resource: "clusterroles",
 }
 
-var clusterRoleBindingGVR = schema.GroupVersionResource{
+var ClusterRoleBinding = schema.GroupVersionResource{
 	Group:    "rbac.authorization.k8s.io",
 	Version:  "v1",
 	Resource: "clusterrolebindings",
 }
 
-var validatingWebhookConfigurationGVR = schema.GroupVersionResource{
+var ValidatingWebhookConfiguration = schema.GroupVersionResource{
 	Group:    "admissionregistration.k8s.io",
 	Version:  "v1",
 	Resource: "validatingwebhookconfigurations",
 }
 
-var mutatingWebhookconfigurationGVR = schema.GroupVersionResource{
+var MutatingWebhookConfiguration = schema.GroupVersionResource{
 	Group:    "admissionregistration.k8s.io",
 	Version:  "v1",
 	Resource: "mutatingwebhookconfigurations",
 }
 
-var istioGVR = schema.GroupVersionResource{
+var Istio = schema.GroupVersionResource{
 	Group:    "istio.banzaicloud.io",
 	Version:  "v1beta1",
 	Resource: "istios",
 }
 
-var meshGatewayGVR = schema.GroupVersionResource{
+var MeshGateway = schema.GroupVersionResource{
 	Group:    "istio.banzaicloud.io",
 	Version:  "v1beta1",
 	Resource: "meshgateways",

--- a/pkg/resources/ingressgateway/k8singress.go
+++ b/pkg/resources/ingressgateway/k8singress.go
@@ -17,9 +17,8 @@ limitations under the License.
 package ingressgateway
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
@@ -55,11 +54,7 @@ func (r *Reconciler) k8sIngressGateway() *k8sutil.DynamicObject {
 	}
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "gateways",
-		},
+		Gvr:       gvr.Gateway,
 		Kind:      "Gateway",
 		Name:      r.Config.WithRevision(k8sIngressGatewayName),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/istiod/meshexpansion.go
+++ b/pkg/resources/istiod/meshexpansion.go
@@ -17,19 +17,14 @@ limitations under the License.
 package istiod
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
 func (r *Reconciler) meshExpansionVirtualService() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "virtualservices",
-		},
+		Gvr:       gvr.VirtualService,
 		Kind:      "VirtualService",
 		Name:      r.Config.WithRevision("meshexpansion-vs-istiod"),
 		Namespace: r.Config.Namespace,
@@ -106,11 +101,7 @@ func (r *Reconciler) meshExpansionDestinationRule() *k8sutil.DynamicObject {
 	}
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "destinationrules",
-		},
+		Gvr:       gvr.DestinationRule,
 		Kind:      "DestinationRule",
 		Name:      r.Config.WithRevision("meshexpansion-dr-istiod"),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/meshexpansion/meshexpansion.go
+++ b/pkg/resources/meshexpansion/meshexpansion.go
@@ -17,9 +17,8 @@ limitations under the License.
 package meshexpansion
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
@@ -49,11 +48,7 @@ func (r *Reconciler) meshExpansionGateway(selector map[string]string) *k8sutil.D
 	}
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "gateways",
-		},
+		Gvr:       gvr.Gateway,
 		Kind:      "Gateway",
 		Name:      r.Config.WithRevision("meshexpansion-gateway"),
 		Namespace: r.Config.Namespace,
@@ -68,11 +63,7 @@ func (r *Reconciler) meshExpansionGateway(selector map[string]string) *k8sutil.D
 
 func (r *Reconciler) clusterAwareGateway(selector map[string]string) *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "gateways",
-		},
+		Gvr:       gvr.Gateway,
 		Kind:      "Gateway",
 		Name:      r.Config.WithRevision("cluster-aware-gateway"),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/meshexpansion/multimesh.go
+++ b/pkg/resources/meshexpansion/multimesh.go
@@ -22,9 +22,8 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
@@ -39,11 +38,7 @@ func (r *Reconciler) multimeshIngressGateway(selector map[string]string) *k8suti
 	}
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "gateways",
-		},
+		Gvr:       gvr.Gateway,
 		Kind:      "Gateway",
 		Name:      r.Config.WithRevision(multimeshResourceNamePrefix + "-ingressgateway"),
 		Namespace: r.Config.Namespace,
@@ -75,11 +70,7 @@ func (r *Reconciler) multimeshEnvoyFilter(selector map[string]string) *k8sutil.D
 	}
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "envoyfilters",
-		},
+		Gvr:       gvr.EnvoyFilter,
 		Kind:      "EnvoyFilter",
 		Name:      r.Config.WithRevision(multimeshResourceNamePrefix + "-ingressgateway"),
 		Namespace: r.Config.Namespace,
@@ -122,11 +113,7 @@ func (r *Reconciler) multimeshEnvoyFilter(selector map[string]string) *k8sutil.D
 
 func (r *Reconciler) multimeshDestinationRule(domain string) *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "destinationrules",
-		},
+		Gvr:       gvr.DestinationRule,
 		Kind:      "DestinationRule",
 		Name:      r.Config.WithRevision(fmt.Sprintf("%s-%08x", multimeshResourceNamePrefix, crc32.ChecksumIEEE([]byte(domain)))),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/mixer/attributes.go
+++ b/pkg/resources/mixer/attributes.go
@@ -17,18 +17,13 @@ limitations under the License.
 package mixer
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 )
 
 func (r *Reconciler) istioProxyAttributeManifest() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "attributemanifests",
-		},
+		Gvr:       gvr.AttributeManifest,
 		Kind:      "attributemanifest",
 		Name:      r.Config.WithRevision("istioproxy"),
 		Namespace: r.Config.Namespace,
@@ -107,11 +102,7 @@ func (r *Reconciler) istioProxyAttributeManifest() *k8sutil.DynamicObject {
 
 func (r *Reconciler) kubernetesAttributeManifest() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "attributemanifests",
-		},
+		Gvr:       gvr.AttributeManifest,
 		Kind:      "attributemanifest",
 		Name:      r.Config.WithRevision("kubernetes"),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/mixer/destinationrule.go
+++ b/pkg/resources/mixer/destinationrule.go
@@ -17,18 +17,13 @@ limitations under the License.
 package mixer
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 )
 
 func (r *Reconciler) policyDestinationRule() *k8sutil.DynamicObject {
 	dr := &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "destinationrules",
-		},
+		Gvr:       gvr.DestinationRule,
 		Kind:      "DestinationRule",
 		Name:      r.Config.WithRevision("istio-policy"),
 		Namespace: r.Config.Namespace,
@@ -50,11 +45,7 @@ func (r *Reconciler) policyDestinationRule() *k8sutil.DynamicObject {
 
 func (r *Reconciler) telemetryDestinationRule() *k8sutil.DynamicObject {
 	dr := &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "destinationrules",
-		},
+		Gvr:       gvr.DestinationRule,
 		Kind:      "DestinationRule",
 		Name:      r.Config.WithRevision("istio-telemetry"),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/mixer/kubernetes.go
+++ b/pkg/resources/mixer/kubernetes.go
@@ -17,19 +17,14 @@ limitations under the License.
 package mixer
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
 func (r *Reconciler) kubernetesEnvHandler() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "handlers",
-		},
+		Gvr:       gvr.IstioConfigHandler,
 		Kind:      "handler",
 		Name:      r.Config.WithRevision("kubernetesenv"),
 		Namespace: r.Config.Namespace,
@@ -44,11 +39,7 @@ func (r *Reconciler) kubernetesEnvHandler() *k8sutil.DynamicObject {
 
 func (r *Reconciler) attributesKubernetes() *k8sutil.DynamicObject {
 	attributes := &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("attributes"),
 		Namespace: r.Config.Namespace,
@@ -104,11 +95,7 @@ func (r *Reconciler) attributesKubernetes() *k8sutil.DynamicObject {
 
 func (r *Reconciler) kubeAttrRule() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "rules",
-		},
+		Gvr:       gvr.IstioConfigRule,
 		Kind:      "rule",
 		Name:      r.Config.WithRevision("kubeattrgenrulerule"),
 		Namespace: r.Config.Namespace,
@@ -127,11 +114,7 @@ func (r *Reconciler) kubeAttrRule() *k8sutil.DynamicObject {
 
 func (r *Reconciler) tcpKubeAttrRule() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "rules",
-		},
+		Gvr:       gvr.IstioConfigRule,
 		Kind:      "rule",
 		Name:      r.Config.WithRevision("tcpkubeattrgenrulerule"),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/mixer/logging.go
+++ b/pkg/resources/mixer/logging.go
@@ -17,19 +17,14 @@ limitations under the License.
 package mixer
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
 func (r *Reconciler) stdioHandler() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "handlers",
-		},
+		Gvr:       gvr.IstioConfigHandler,
 		Kind:      "handler",
 		Name:      r.Config.WithRevision("stdio"),
 		Namespace: r.Config.Namespace,
@@ -46,11 +41,7 @@ func (r *Reconciler) stdioHandler() *k8sutil.DynamicObject {
 
 func (r *Reconciler) accessLogLogentry() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("accesslog"),
 		Namespace: r.Config.Namespace,
@@ -112,11 +103,7 @@ func (r *Reconciler) accessLogLogentry() *k8sutil.DynamicObject {
 
 func (r *Reconciler) tcpAccessLogLogentry() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("tcpaccesslog"),
 		Namespace: r.Config.Namespace,
@@ -163,11 +150,7 @@ func (r *Reconciler) tcpAccessLogLogentry() *k8sutil.DynamicObject {
 
 func (r *Reconciler) stdioRule() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "rules",
-		},
+		Gvr:       gvr.IstioConfigRule,
 		Kind:      "rule",
 		Name:      r.Config.WithRevision("stdio"),
 		Namespace: r.Config.Namespace,
@@ -187,11 +170,7 @@ func (r *Reconciler) stdioRule() *k8sutil.DynamicObject {
 
 func (r *Reconciler) stdioTcpRule() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "rules",
-		},
+		Gvr:       gvr.IstioConfigRule,
 		Kind:      "rule",
 		Name:      r.Config.WithRevision("stdiotcp"),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/mixer/monitoring.go
+++ b/pkg/resources/mixer/monitoring.go
@@ -17,20 +17,15 @@ limitations under the License.
 package mixer
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
 func (r *Reconciler) prometheusHandler() *k8sutil.DynamicObject {
 	multiClusterEnabled := util.PointerToBool(r.Config.Spec.Mixer.MultiClusterSupport)
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "handlers",
-		},
+		Gvr:       gvr.IstioConfigHandler,
 		Kind:      "handler",
 		Name:      r.Config.WithRevision("prometheus"),
 		Namespace: r.Config.Namespace,
@@ -116,11 +111,7 @@ func (r *Reconciler) prometheusHandler() *k8sutil.DynamicObject {
 func (r *Reconciler) requestCountMetric() *k8sutil.DynamicObject {
 	multiClusterEnabled := util.PointerToBool(r.Config.Spec.Mixer.MultiClusterSupport)
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("requestcount"),
 		Namespace: r.Config.Namespace,
@@ -140,11 +131,7 @@ func (r *Reconciler) requestCountMetric() *k8sutil.DynamicObject {
 func (r *Reconciler) requestDurationMetric() *k8sutil.DynamicObject {
 	multiClusterEnabled := util.PointerToBool(r.Config.Spec.Mixer.MultiClusterSupport)
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("requestduration"),
 		Namespace: r.Config.Namespace,
@@ -164,11 +151,7 @@ func (r *Reconciler) requestDurationMetric() *k8sutil.DynamicObject {
 func (r *Reconciler) requestSizeMetric() *k8sutil.DynamicObject {
 	multiClusterEnabled := util.PointerToBool(r.Config.Spec.Mixer.MultiClusterSupport)
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("requestsize"),
 		Namespace: r.Config.Namespace,
@@ -188,11 +171,7 @@ func (r *Reconciler) requestSizeMetric() *k8sutil.DynamicObject {
 func (r *Reconciler) responseSizeMetric() *k8sutil.DynamicObject {
 	multiClusterEnabled := util.PointerToBool(r.Config.Spec.Mixer.MultiClusterSupport)
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("responsesize"),
 		Namespace: r.Config.Namespace,
@@ -212,11 +191,7 @@ func (r *Reconciler) responseSizeMetric() *k8sutil.DynamicObject {
 func (r *Reconciler) tcpByteSentMetric() *k8sutil.DynamicObject {
 	multiClusterEnabled := util.PointerToBool(r.Config.Spec.Mixer.MultiClusterSupport)
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("tcpbytesent"),
 		Namespace: r.Config.Namespace,
@@ -236,11 +211,7 @@ func (r *Reconciler) tcpByteSentMetric() *k8sutil.DynamicObject {
 func (r *Reconciler) tcpByteReceivedMetric() *k8sutil.DynamicObject {
 	multiClusterEnabled := util.PointerToBool(r.Config.Spec.Mixer.MultiClusterSupport)
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("tcpbytereceived"),
 		Namespace: r.Config.Namespace,
@@ -260,11 +231,7 @@ func (r *Reconciler) tcpByteReceivedMetric() *k8sutil.DynamicObject {
 func (r *Reconciler) tcpConnectionsOpenedMetric() *k8sutil.DynamicObject {
 	multiClusterEnabled := util.PointerToBool(r.Config.Spec.Mixer.MultiClusterSupport)
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("tcpconnectionsopened"),
 		Namespace: r.Config.Namespace,
@@ -284,11 +251,7 @@ func (r *Reconciler) tcpConnectionsOpenedMetric() *k8sutil.DynamicObject {
 func (r *Reconciler) tcpConnectionsClosedMetric() *k8sutil.DynamicObject {
 	multiClusterEnabled := util.PointerToBool(r.Config.Spec.Mixer.MultiClusterSupport)
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "instances",
-		},
+		Gvr:       gvr.IstioConfigInstance,
 		Kind:      "instance",
 		Name:      r.Config.WithRevision("tcpconnectionsclosed"),
 		Namespace: r.Config.Namespace,
@@ -307,11 +270,7 @@ func (r *Reconciler) tcpConnectionsClosedMetric() *k8sutil.DynamicObject {
 
 func (r *Reconciler) promHttpRule() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "rules",
-		},
+		Gvr:       gvr.IstioConfigRule,
 		Kind:      "rule",
 		Name:      r.Config.WithRevision("promhttp"),
 		Namespace: r.Config.Namespace,
@@ -331,11 +290,7 @@ func (r *Reconciler) promHttpRule() *k8sutil.DynamicObject {
 
 func (r *Reconciler) promTcpRule() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "rules",
-		},
+		Gvr:       gvr.IstioConfigRule,
 		Kind:      "rule",
 		Name:      r.Config.WithRevision("promtcp"),
 		Namespace: r.Config.Namespace,
@@ -355,11 +310,7 @@ func (r *Reconciler) promTcpRule() *k8sutil.DynamicObject {
 
 func (r *Reconciler) promTcpConnectionOpenRule() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "rules",
-		},
+		Gvr:       gvr.IstioConfigRule,
 		Kind:      "rule",
 		Name:      r.Config.WithRevision("promtcpconnectionopen"),
 		Namespace: r.Config.Namespace,
@@ -379,11 +330,7 @@ func (r *Reconciler) promTcpConnectionOpenRule() *k8sutil.DynamicObject {
 
 func (r *Reconciler) promTcpConnectionClosedRule() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "config.istio.io",
-			Version:  "v1alpha2",
-			Resource: "rules",
-		},
+		Gvr:       gvr.IstioConfigRule,
 		Kind:      "rule",
 		Name:      r.Config.WithRevision("promtcpconnectionclosed"),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/mixerlesstelemetry/meta_exchange_filter.go
+++ b/pkg/resources/mixerlesstelemetry/meta_exchange_filter.go
@@ -21,11 +21,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/banzaicloud/istio-operator/pkg/util"
 	"github.com/ghodss/yaml"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
+	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
 const (
@@ -58,11 +58,7 @@ func (r *Reconciler) metaExchangeEnvoyFilter(version string, metadataExchangeFil
 	yaml.Unmarshal([]byte(fmt.Sprintf(metadataExchangeFilterYAML, vmConfigLocal, vmConfigRuntime, strconv.FormatBool(vmConfigAllowPrecompiled), r.metadataMatch(8))), &y)
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "envoyfilters",
-		},
+		Gvr:       gvr.EnvoyFilter,
 		Kind:      "EnvoyFilter",
 		Name:      r.Config.WithRevision(fmt.Sprintf("%s-metadata-exchange-%s", componentName, version)),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/mixerlesstelemetry/stats_filter.go
+++ b/pkg/resources/mixerlesstelemetry/stats_filter.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/banzaicloud/istio-operator/pkg/util"
 	"github.com/ghodss/yaml"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
+	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
 const (
@@ -48,11 +48,7 @@ func (r *Reconciler) httpStatsFilter(version string, httpStatsFilterYAML string)
 	yaml.Unmarshal([]byte(fmt.Sprintf(httpStatsFilterYAML, vmConfigLocal, vmConfigRuntime, strconv.FormatBool(vmConfigAllowPrecompiled), r.metadataMatch(8))), &y)
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "envoyfilters",
-		},
+		Gvr:       gvr.EnvoyFilter,
 		Kind:      "EnvoyFilter",
 		Name:      r.Config.WithRevision(fmt.Sprintf("%s-stats-filter-%s", componentName, version)),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/mixerlesstelemetry/tcp_meta_exchange_filter.go
+++ b/pkg/resources/mixerlesstelemetry/tcp_meta_exchange_filter.go
@@ -20,9 +20,9 @@ import (
 	"fmt"
 
 	"github.com/ghodss/yaml"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 )
 
 func (r *Reconciler) tcpMetaExchangeEnvoyFilter(version string, tcpMetadataExchangeFilterYAML string) *k8sutil.DynamicObject {
@@ -30,11 +30,7 @@ func (r *Reconciler) tcpMetaExchangeEnvoyFilter(version string, tcpMetadataExcha
 	yaml.Unmarshal([]byte(fmt.Sprintf(tcpMetadataExchangeFilterYAML, r.metadataMatch(12))), &y)
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "envoyfilters",
-		},
+		Gvr:       gvr.EnvoyFilter,
 		Kind:      "EnvoyFilter",
 		Name:      r.Config.WithRevision(fmt.Sprintf("%s-tcp-metadata-exchange-%s", componentName, version)),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/mixerlesstelemetry/tcp_stats_filter.go
+++ b/pkg/resources/mixerlesstelemetry/tcp_stats_filter.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/banzaicloud/istio-operator/pkg/util"
 	"github.com/ghodss/yaml"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
+	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
 func (r *Reconciler) tcpStatsFilter(version string, tcpStatsFilterYAML string) *k8sutil.DynamicObject {
@@ -43,11 +43,7 @@ func (r *Reconciler) tcpStatsFilter(version string, tcpStatsFilterYAML string) *
 	yaml.Unmarshal([]byte(fmt.Sprintf(tcpStatsFilterYAML, vmConfigLocal, vmConfigRuntime, strconv.FormatBool(vmConfigAllowPrecompiled), r.metadataMatch(10))), &y)
 
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "envoyfilters",
-		},
+		Gvr:       gvr.EnvoyFilter,
 		Kind:      "EnvoyFilter",
 		Name:      r.Config.WithRevision(fmt.Sprintf("%s-tcp-stats-filter-%s", componentName, version)),
 		Namespace: r.Config.Namespace,

--- a/pkg/resources/pilot/meshexpansion.go
+++ b/pkg/resources/pilot/meshexpansion.go
@@ -17,19 +17,14 @@ limitations under the License.
 package pilot
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/pkg/util"
 )
 
 func (r *Reconciler) meshExpansionVirtualService() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "virtualservices",
-		},
+		Gvr:       gvr.VirtualService,
 		Kind:      "VirtualService",
 		Name:      r.Config.WithRevision("meshexpansion-vs-pilot"),
 		Namespace: r.Config.Namespace,
@@ -67,11 +62,7 @@ func (r *Reconciler) meshExpansionVirtualService() *k8sutil.DynamicObject {
 
 func (r *Reconciler) meshExpansionDestinationRule() *k8sutil.DynamicObject {
 	return &k8sutil.DynamicObject{
-		Gvr: schema.GroupVersionResource{
-			Group:    "networking.istio.io",
-			Version:  "v1alpha3",
-			Resource: "destinationrules",
-		},
+		Gvr:       gvr.DestinationRule,
 		Kind:      "DestinationRule",
 		Name:      r.Config.WithRevision("meshexpansion-dr-pilot"),
 		Namespace: r.Config.Namespace,

--- a/scripts/e2e-test/setup-env.sh
+++ b/scripts/e2e-test/setup-env.sh
@@ -2,14 +2,20 @@
 
 set -euo pipefail
 
-[ -z "${1:-}" ] && { echo "Usage: $0 <istio-version>"; exit 1; }
+readonly kubernetes_version=${1:-}
+readonly istio_version=${2:-}
 
-readonly istio_version=$1
+if [ -z "${kubernetes_version}" ] || [ -z "${istio_version}" ]; then
+    echo "Usage: $0 <kubernetes-version> <istio-version>"
+    echo "Note: <kubernetes-version> must be a version for which there is a KinD node image, e.g. 1.19.7"
+    echo "      Look for supported versions at https://hub.docker.com/r/kindest/node/tags"
+    exit 1
+fi
 
 readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 readonly scripts_dir=${script_dir}/..
 
-kind create cluster
+kind create cluster --image "kindest/node:v${kubernetes_version}"
 
 # TODO get these from the MetalLB resource yaml
 docker pull metallb/controller:v0.9.6

--- a/test/e2e/gvrs.go
+++ b/test/e2e/gvrs.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+var serviceGVR = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "services",
+}
+
+var podGVR = schema.GroupVersionResource{
+	Group:    "",
+	Version:  "v1",
+	Resource: "pods",
+}
+
+var deploymentGVR = schema.GroupVersionResource{
+	Group:    "apps",
+	Version:  "v1",
+	Resource: "deployments",
+}
+
+var horizontalPodAutoscalerGVR = schema.GroupVersionResource{
+	Group:    "autoscaling",
+	Version:  "v1",
+	Resource: "horizontalpodautoscalers",
+}
+
+var clusterRoleGVR = schema.GroupVersionResource{
+	Group:    "rbac.authorization.k8s.io",
+	Version:  "v1",
+	Resource: "clusterroles",
+}
+
+var clusterRoleBindingGVR = schema.GroupVersionResource{
+	Group:    "rbac.authorization.k8s.io",
+	Version:  "v1",
+	Resource: "clusterrolebindings",
+}
+
+var validatingWebhookConfigurationGVR = schema.GroupVersionResource{
+	Group:    "admissionregistration.k8s.io",
+	Version:  "v1",
+	Resource: "validatingwebhookconfigurations",
+}
+
+var mutatingWebhookconfigurationGVR = schema.GroupVersionResource{
+	Group:    "admissionregistration.k8s.io",
+	Version:  "v1",
+	Resource: "mutatingwebhookconfigurations",
+}
+
+var istioGVR = schema.GroupVersionResource{
+	Group:    "istio.banzaicloud.io",
+	Version:  "v1beta1",
+	Resource: "istios",
+}
+
+var meshGatewayGVR = schema.GroupVersionResource{
+	Group:    "istio.banzaicloud.io",
+	Version:  "v1beta1",
+	Resource: "meshgateways",
+}

--- a/test/e2e/istio_controller_suite_test.go
+++ b/test/e2e/istio_controller_suite_test.go
@@ -41,18 +41,18 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	clusterStateBefore, err := listAllResources(testEnv.Client)
+	clusterStateBefore, err := listAllResources(testEnv.Dynamic)
 	if err != nil {
 		panic(err)
 	}
 
 	code := m.Run()
 
-	clusterStateAfter, err := listAllResources(testEnv.Client)
+	clusterStateAfter, err := listAllResources(testEnv.Dynamic)
 	if err != nil {
 		panic(err)
 	}
-	if !clusterIsClean(*clusterStateBefore, *clusterStateAfter) {
+	if !clusterIsClean(clusterStateBefore, clusterStateAfter) {
 		log.Info("cluster resources before", "clusterStateBefore", clusterStateBefore)
 		log.Info("cluster resources after", "clusterStateAfter", clusterStateAfter)
 		panic("Cluster wasn't cleaned up properly")

--- a/test/e2e/istio_controller_test.go
+++ b/test/e2e/istio_controller_test.go
@@ -37,7 +37,7 @@ func TestIstioOperator(t *testing.T) {
 	const instanceName = "istio"
 	instance := mkMinimalIstio(namespace, instanceName)
 
-	istioTestEnv := NewIstioTestEnv(t, testEnv.Client, instance)
+	istioTestEnv := NewIstioTestEnv(t, testEnv.Client, testEnv.Dynamic, instance)
 	istioTestEnv.Start()
 	defer func() {
 		if t.Failed() {
@@ -50,7 +50,7 @@ func TestIstioOperator(t *testing.T) {
 	istioTestEnv.WaitForIstioReconcile()
 
 	// TODO extract this and related code
-	clusterStateBeforeTests, err := listAllResources(testEnv.Client)
+	clusterStateBeforeTests, err := listAllResources(testEnv.Dynamic)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	t.Run("Istio resource stays reconciled (Available)", func(t *testing.T) {
@@ -59,7 +59,7 @@ func TestIstioOperator(t *testing.T) {
 			if t.Failed() {
 				t.Log("Test failed, not cleaning up")
 			} else {
-				WaitForCleanup(t, g, *clusterStateBeforeTests, 1*time.Second, 100*time.Millisecond)
+				WaitForCleanup(t, g, clusterStateBeforeTests, 1*time.Second, 100*time.Millisecond)
 			}
 		}()
 
@@ -88,7 +88,7 @@ func TestIstioOperator(t *testing.T) {
 				t.Log("Test failed, not cleaning up")
 			} else {
 				resources.MustDeleteResources(t, testEnv.Client, resourcesFile)
-				WaitForCleanup(t, g, *clusterStateBeforeTests, 60*time.Second, 100*time.Millisecond)
+				WaitForCleanup(t, g, clusterStateBeforeTests, 60*time.Second, 100*time.Millisecond)
 			}
 		}()
 

--- a/test/e2e/istio_controller_test_helpers.go
+++ b/test/e2e/istio_controller_test_helpers.go
@@ -460,7 +460,7 @@ func sortNamespacedNames(nns []types.NamespacedName) {
 		if nns[i].Namespace < nns[j].Namespace {
 			return true
 		}
-		if nns[i].Namespace == nns[j].Namespace {
+		if nns[i].Namespace > nns[j].Namespace {
 			return false
 		}
 

--- a/test/e2e/istio_controller_test_helpers.go
+++ b/test/e2e/istio_controller_test_helpers.go
@@ -42,6 +42,7 @@ import (
 
 	istiov1beta1 "github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
 	"github.com/banzaicloud/istio-operator/pkg/k8sutil/mgw"
+	"github.com/banzaicloud/istio-operator/pkg/resources/gvr"
 	"github.com/banzaicloud/istio-operator/test/e2e/util"
 )
 
@@ -113,7 +114,7 @@ func (e *IstioTestEnv) WaitForIstioReconcile() {
 	g := gomega.NewWithT(e.t)
 
 	e.t.Log("Waiting for Istio resource to be reconciled")
-	err := WaitForStatus(istioGVR, e.istio.Namespace, e.istio.Name, string(istiov1beta1.Available), 300*time.Second, 1000*time.Millisecond)
+	err := WaitForStatus(gvr.Istio, e.istio.Namespace, e.istio.Name, string(istiov1beta1.Available), 300*time.Second, 1000*time.Millisecond)
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "waiting for Istio resource to be reconciled")
 	e.t.Log("Istio resource is reconciled")
 }
@@ -166,7 +167,7 @@ func GetMeshGatewayAddress(mgw01Namespace string, mgw01Name string, timeout time
 	var meshGatewayAddresses []string
 	err := util.WaitForCondition(timeout, interval, func() (bool, error) {
 		var err error
-		status, err := GetStatus(context.TODO(), testEnv.Dynamic, meshGatewayGVR, mgw01Namespace, mgw01Name)
+		status, err := GetStatus(context.TODO(), testEnv.Dynamic, gvr.MeshGateway, mgw01Namespace, mgw01Name)
 		if err != nil {
 			return false, err
 		}
@@ -205,7 +206,7 @@ y:
 	for {
 		select {
 		case <-ticker.C:
-			status, err := GetStatus(context.TODO(), testEnv.Dynamic, istioGVR, namespace, name)
+			status, err := GetStatus(context.TODO(), testEnv.Dynamic, gvr.Istio, namespace, name)
 			if err != nil {
 				return false, err
 			}
@@ -342,15 +343,16 @@ func clusterIsClean(before ClusterResourceList, after ClusterResourceList) bool 
 // TODO add more resource types
 func listAllResources(d dynamic.Interface) (ClusterResourceList, error) {
 	gvrs := []schema.GroupVersionResource{
-		serviceGVR,
-		podGVR,
-		deploymentGVR,
-		horizontalPodAutoscalerGVR,
-		clusterRoleGVR,
-		clusterRoleBindingGVR,
-		validatingWebhookConfigurationGVR,
-		mutatingWebhookconfigurationGVR,
-		istioGVR,meshGatewayGVR,
+		gvr.Service,
+		gvr.Pod,
+		gvr.Deployment,
+		gvr.HorizontalPodAutoscaler,
+		gvr.ClusterRole,
+		gvr.ClusterRoleBinding,
+		gvr.ValidatingWebhookConfiguration,
+		gvr.MutatingWebhookConfiguration,
+		gvr.Istio,
+		gvr.MeshGateway,
 	}
 
 	result := make(ClusterResourceList)

--- a/test/e2e/istio_controller_test_helpers.go
+++ b/test/e2e/istio_controller_test_helpers.go
@@ -362,10 +362,13 @@ func listAllResources(d dynamic.Interface) (ClusterResourceList, error) {
 	result := make(ClusterResourceList)
 	for _, gvr := range gvrs {
 		items, err := listResources(d, gvr)
-		if err != nil {
+		if err != nil && !k8sapierrors.IsNotFound(err) {
 			return nil, err
 		}
 		gvrString := groupVersionResourceString(gvr.String())
+		if items == nil {
+			items = []types.NamespacedName{}
+		}
 		result[gvrString] = items
 	}
 	return result, nil

--- a/test/e2e/istio_controller_test_helpers.go
+++ b/test/e2e/istio_controller_test_helpers.go
@@ -339,7 +339,6 @@ func clusterIsClean(before ClusterResourceList, after ClusterResourceList) bool 
 	return reflect.DeepEqual(before, after)
 }
 
-
 // TODO add more resource types
 func listAllResources(d dynamic.Interface) (ClusterResourceList, error) {
 	gvrs := []schema.GroupVersionResource{
@@ -351,6 +350,11 @@ func listAllResources(d dynamic.Interface) (ClusterResourceList, error) {
 		gvr.ClusterRoleBinding,
 		gvr.ValidatingWebhookConfiguration,
 		gvr.MutatingWebhookConfiguration,
+		gvr.DestinationRule,
+		gvr.VirtualService,
+		gvr.PeerAuthentication,
+		gvr.Gateway,
+		gvr.EnvoyFilter,
 		gvr.Istio,
 		gvr.MeshGateway,
 	}

--- a/test/e2e/istio_controller_test_helpers.go
+++ b/test/e2e/istio_controller_test_helpers.go
@@ -63,7 +63,7 @@ type IstioTestEnv struct {
 	c     client.Client
 	istio *istiov1beta1.Istio
 
-	clusterStateBefore *ClusterState
+	clusterStateBefore *ClusterResourceList
 }
 
 func NewIstioTestEnv(t *testing.T, c client.Client, istio *istiov1beta1.Istio) IstioTestEnv {
@@ -99,7 +99,7 @@ func (e *IstioTestEnv) Close() {
 	WaitForCleanup(e.t, g, *e.clusterStateBefore, 120*time.Second, 100*time.Millisecond)
 }
 
-func WaitForCleanup(t *testing.T, g *gomega.WithT, expectedClusterState ClusterState, timeout time.Duration, interval time.Duration) {
+func WaitForCleanup(t *testing.T, g *gomega.WithT, expectedClusterState ClusterResourceList, timeout time.Duration, interval time.Duration) {
 	t.Log("Waiting for cleanup")
 	err := util.WaitForCondition(timeout, interval, func() (bool, error) {
 		currentClusterState, err := listAllResources(testEnv.Client)
@@ -342,7 +342,7 @@ func HPAExists(ctx context.Context, t *testing.T, kubeClient client.Client, name
 }
 
 // TODO this should be a `map[metav1.GroupVersionKind][]types.NamespacedName`
-type ClusterState struct {
+type ClusterResourceList struct {
 	Istios      []types.NamespacedName
 	Deployments []types.NamespacedName
 	Pods        []types.NamespacedName
@@ -350,12 +350,12 @@ type ClusterState struct {
 	Hpas        []types.NamespacedName
 }
 
-func clusterIsClean(before ClusterState, after ClusterState) bool {
+func clusterIsClean(before ClusterResourceList, after ClusterResourceList) bool {
 	return reflect.DeepEqual(before, after)
 }
 
 // TODO add more resource types
-func listAllResources(client client.Client) (*ClusterState, error) {
+func listAllResources(client client.Client) (*ClusterResourceList, error) {
 	istios, err := listIstios(client)
 	if err != nil {
 		return nil, err
@@ -376,7 +376,7 @@ func listAllResources(client client.Client) (*ClusterState, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &ClusterState{istios, deployments, pods, services, hpas}, nil
+	return &ClusterResourceList{istios, deployments, pods, services, hpas}, nil
 }
 
 // TODO rewrite these using the dynamic client

--- a/test/e2e/istio_controller_test_helpers.go
+++ b/test/e2e/istio_controller_test_helpers.go
@@ -346,6 +346,10 @@ func listAllResources(d dynamic.Interface) (ClusterResourceList, error) {
 		podGVR,
 		deploymentGVR,
 		horizontalPodAutoscalerGVR,
+		clusterRoleGVR,
+		clusterRoleBindingGVR,
+		validatingWebhookConfigurationGVR,
+		mutatingWebhookconfigurationGVR,
 		istioGVR,meshGatewayGVR,
 	}
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #643 
| License         | Apache 2.0


### What's in this PR?

Several small end-to-end test fixes/cleanups, and a "workaround" for resource cleanup after deletion of Istio resources. The "workaround" is to use an older kubernetes version for end-to-end testing, which does clean up all resources.


### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

