### PR TITLE
[v2] Add flag to skip Istio api dependency update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ LICENSEI_VERSION = 0.3.1
 KUBEBUILDER_VERSION = 2.3.2
 KUSTOMIZE_VERSION = 4.1.2
 ISTIO_VERSION = 1.10.0-alpha.1
+SKIP_ISTIO_API_UPDATE = false
 BUF_VERSION = 0.41.0
 
 PATH := $(PATH):$(PWD)/bin
@@ -105,7 +106,7 @@ download-deps:
 
 # Update Istio build dependencies
 update-istio-deps:
-	./scripts/update-istio-dependencies.sh $(ISTIO_VERSION)
+	./scripts/update-istio-dependencies.sh $(ISTIO_VERSION) $(SKIP_ISTIO_API_UPDATE)
 
 # Generate code
 generate: download-deps update-istio-deps

--- a/scripts/remove-istio-dependencies.sh
+++ b/scripts/remove-istio-dependencies.sh
@@ -9,6 +9,6 @@ build_dir=$1
 pushd ${build_dir}
 
 echo "cleanup"
-rm -rf api common-protos github.com gogoproto google istio.io k8s.io mesh networking ../mesh ../networking
+rm -rf api common-protos github.com gogoproto google istio.io k8s.io mesh networking
 
 popd

--- a/scripts/update-istio-dependencies.sh
+++ b/scripts/update-istio-dependencies.sh
@@ -6,6 +6,13 @@ set -euo pipefail
 
 version=$1
 
+skip="${2:-false}"
+if [ "$skip" = true ]
+then
+  echo "skipping istio api dependency update because skip flag is set to true"
+  exit 0
+fi
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 build_dir=${script_dir}/../build
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add `SKIP_ISTIO_API_UPDATE` flag to `update-istio-dependencies.sh` to be able to skip Istio API dependency update.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To be able to run e.g. `make manifests generate SKIP_ISTIO_API_UPDATE=true`, which is useful during istio operator API development when our own API constantly changing and we often regenerate the API and CRDs, but the Istio version does not change and hence it is unnecessary to remove and then clone the `istio/api` repo again and again. 

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

This is only an optional flag used for development. It is NOT enabled by default, so that it is never forgotten to actually update the API when there is an Istio version bump.

BTW, we already implicitly make sure that API update is not forgotten in the CI during this check: https://github.com/banzaicloud/istio-operator/blob/v2/.circleci/config.yml#L48-L50

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
