### PR TITLE
Add basic log collection for e2e test failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,7 @@ jobs:
       - run:
           name: Compress E2E test dump
           command: tar czf e2e-test-dump.tar.gz logs
+          when: always
       - store_artifacts:
           path: e2e-test-dump.tar.gz
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,11 @@ jobs:
       - run:
           name: Run E2E test
           command: make e2e-test E2E_TEST_TAG=<<parameters.tag>>
+      - run:
+          name: Compress E2E test dump
+          command: tar czf e2e-test-dump.tar.gz logs
+      - store_artifacts:
+          path: e2e-test-dump.tar.gz
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ bin/*
 cover.out
 
 manager_image_patch.yaml
+
+/logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.13.9
 # Build the manager binary
 FROM golang:${GO_VERSION}-alpine3.11 AS builder
 
-RUN apk add --update --no-cache ca-certificates make~=4.2 git~=2.24 curl~=7.67 mercurial~=5.3
+RUN apk add --update --no-cache ca-certificates make~=4.2 git~=2.24 curl~=7.67 mercurial~=5.3 bash~=5
 
 ARG PACKAGE=github.com/banzaicloud/istio-operator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 
 COPY pkg/    pkg/
 COPY cmd/    cmd/
+COPY test/e2e/e2e-test.mk /go/src/${PACKAGE}/test/e2e/
 COPY Makefile go.* /go/src/${PACKAGE}/
 RUN make vendor
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -3,7 +3,7 @@ ARG GO_VERSION=1.13.9
 # Build the manager binary
 FROM golang:${GO_VERSION}-alpine3.11 AS builder
 
-RUN apk add --update --no-cache ca-certificates make~=4.2 git~=2.24 curl~=7.67 mercurial~=5.3
+RUN apk add --update --no-cache ca-certificates make~=4.2 git~=2.24 curl~=7.67 mercurial~=5.3 bash~=5
 
 ARG PACKAGE=github.com/banzaicloud/istio-operator
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -16,6 +16,7 @@ RUN go mod download
 COPY pkg/    pkg/
 COPY cmd/    cmd/
 COPY vendor/ vendor/
+COPY test/e2e/e2e-test.mk /go/src/${PACKAGE}/test/e2e/
 COPY Makefile go.* /go/src/${PACKAGE}/
 
 # Build

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-SHELL := /bin/bash -euo pipefail
+# Using -u (unset variable) results in an error on CircleCI (/etc/bash.bashrc uses unset "PS1")
+SHELL := /bin/bash -eo pipefail
 
 # Image URL to use all building/pushing image targets
 TAG ?= $(shell git describe --tags --abbrev=0 --match '[0-9].*[0-9].*[0-9]' 2>/dev/null )

--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,7 @@ IMG ?= ${IMAGE_REPOSITORY}:$(TAG)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS = "crd:trivialVersions=true,maxDescLen=0,preserveUnknownFields=false,allowDangerousTypes=true"
 
-# When running the end-to-end tests, an istio-operator docker image is built from the local
-# source, then loaded into the kind cluster as `banzaicloud/istio-operator:${E2E_TEST_TAG}`.
-# The reason for using this variable instead of `TAG` is to make sure the pod isn't showing
-# a released version tag (the `TAG` variable defaults to the latest released version).
-# Without this variable, the installed istio-operator pod would contain something like
-# `image: banzaicloud/istio-operator:0.9.3`, but it would _not_ be running the 0.9.3 version
-# of istio-operator. On the other hand, if for some reason the image is not loaded into the
-# cluster before installing the istio-operator, the `banzaicloud/istio-operator:0.9.3` image
-# would be pulled down and started, which wouldn't be the expected image.
-# To avoid this and similar issues, the tag is forced to be some other value: `e2e-test` by
-# default, or the current branch name on the CI.
-# Currently, it's not possible to run the tests with a different istio-operator version.
-E2E_TEST_TAG ?= e2e-test
+include test/e2e/e2e-test.mk
 
 TEST_RACE_DETECTOR ?= 0
 
@@ -147,45 +135,6 @@ docker-build: vendor
 # Push the docker image
 docker-push:
 	docker push ${IMG}
-
-.PHONY: e2e-test-dependencies
-e2e-test-dependencies:
-	./scripts/e2e-test/download-deps.sh
-
-.PHONY: e2e-test-env
-e2e-test-env: e2e-test-dependencies
-	# There's an issue (https://github.com/banzaicloud/istio-operator/issues/643) with resource cleanup on
-	# k8s 1.20, so running the tests on 1.19.7 for now
-	env PATH=./bin:$${PATH} ./scripts/e2e-test/setup-env.sh 1.19.7 ${ISTIO_VERSION}
-
-.PHONY: e2e-test-install-istio-operator
-e2e-test-install-istio-operator: export PATH:=./bin:${PATH}
-e2e-test-install-istio-operator: TAG=${E2E_TEST_TAG}
-e2e-test-install-istio-operator: docker-build
-	# TODO build with TEST_RACE_DETECTOR=1 in docker-build
-	kind load docker-image ${IMG}
-	helm install --wait \
-		--set operator.image.repository=${IMAGE_REPOSITORY} \
-		--set operator.image.tag=${TAG} \
-		--create-namespace \
-		--namespace istio-system \
-		istio-operator-e2e-test \
-		deploy/charts/istio-operator/
-
-	# Wait for all pods to be ready. `helm --wait` only waits for the pods installed by helm. Usually,
-	# when the istio-operator is ready, a couple of pods in kube-system are still just starting up. It
-	# works out fine now, probably because there is a wait in TestMain for the cluster to be reachable.
-	# Waiting here for all pods might result in a lower load on the cluster when the actual tests
-	# start, so it might remove some flakiness.
-	kubectl wait pod --all-namespaces --all --for=condition=ready --timeout=60s
-
-.PHONY: e2e-test
-e2e-test: export PATH:=./bin:${PATH}
-e2e-test: download-deps e2e-test-install-istio-operator
-	bin/ginkgo --failFast --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/...
-
-    # TODO collect used docker images and compare with known list. This list can be used to preload the images into kind
-    # TODO  `kind export logs` and look for "ImageCreate" in containerd.log
 
 check_release:
 	@echo "A new tag (${REL_TAG}) will be pushed to Github, and a new Docker image will be released. Are you sure? [y/N] " && read -r ans && [ "$${ans:-N}" = y ]

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash -euo pipefail
+
 # Image URL to use all building/pushing image targets
 TAG ?= $(shell git describe --tags --abbrev=0 --match '[0-9].*[0-9].*[0-9]' 2>/dev/null )
 IMAGE_REPOSITORY ?= banzaicloud/istio-operator

--- a/scripts/dump-cluster-state-and-logs.sh
+++ b/scripts/dump-cluster-state-and-logs.sh
@@ -4,16 +4,46 @@ set -euo pipefail
 
 readonly dump_dir=${1:-}
 
-[ -z "${dump_dir}" ] && { echo "Usage: $0 <dump-dir>"; exit 1; }
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+readonly bin_path=${script_dir}/../bin
+export PATH=${bin_path}:$PATH
+
+[ -z "${dump_dir}" ] && {
+    echo "Usage: $0 <dump-dir>"
+    exit 1
+}
 
 mkdir -p "${dump_dir}"
 
-function dump-cluster-state {
-    echo "dumping cluster state" > "${dump_dir}"/cluster-state
+function dump-cluster-state() {
+    local dir="${dump_dir}"/resources
+    mkdir -p "${dir}"
+
+    # This list should probably match the list in test/e2e/e2e_helpers_test.go:listAllResources()
+    local -a kinds=(
+        crd service pod deployment horizontalpodautoscaler clusterrole clusterrolebinding
+        validatingwebhookconfiguration mutatingwebhookconfiguration destinationrule
+        virtualservice peerauthentication gateway envoyfilter istio meshgateway
+    )
+    for kind in "${kinds[@]}"; do
+        kubectl get "$kind" -A -o yaml > "$dir/$kind".yaml
+    done
 }
 
-function dump-logs {
-    echo "dumping logs" > "${dump_dir}"/logs
+function dump-logs() {
+    local namespaces
+    namespaces=$(kubectl get namespace -o name)
+    for ns in ${namespaces[*]}; do
+        ns=${ns##namespace/}
+        for pod in $(kubectl get -n "$ns" pod -o name); do
+            pod=${pod##pod/}
+            for container in $(kubectl get -n "$ns" pod "$pod" -o template='{{range .spec.containers}}{{.name}}{{"\n"}}{{end}}'); do
+                local dir="${dump_dir}/logs/$ns/$pod"
+                mkdir -p "$dir"
+                kubectl logs -n "$ns" "$pod" -c "$container" >"$dir/$container.log"
+            done
+        done
+    done
 }
 
 dump-cluster-state

--- a/scripts/dump-cluster-state-and-logs.sh
+++ b/scripts/dump-cluster-state-and-logs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly dump_dir=${1:-}
+
+[ -z "${dump_dir}" ] && { echo "Usage: $0 <dump-dir>"; exit 1; }
+
+mkdir -p "${dump_dir}"
+
+function dump-cluster-state {
+    echo "dumping cluster state" > "${dump_dir}"/cluster-state
+}
+
+function dump-logs {
+    echo "dumping logs" > "${dump_dir}"/logs
+}
+
+dump-cluster-state
+dump-logs

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -12,6 +12,12 @@
 # Currently, it's not possible to run the tests with a different istio-operator version.
 E2E_TEST_TAG ?= e2e-test
 
+E2E_TEST_FAIL_FAST ?= 0
+
+ifeq (${E2E_TEST_FAIL_FAST}, 1)
+	E2E_TEST_GINKGO_ARGS += --failFast
+endif
+
 .PHONY: e2e-test-dependencies
 e2e-test-dependencies:
 	./scripts/e2e-test/download-deps.sh
@@ -45,7 +51,8 @@ e2e-test-install-istio-operator: docker-build
 
 .PHONY: e2e-test
 e2e-test: download-deps e2e-test-install-istio-operator
-	bin/ginkgo --failFast --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/...
+	env E2E_TEST_FAIL_FAST=${E2E_TEST_FAIL_FAST} \
+		bin/ginkgo ${E2E_TEST_GINKGO_ARGS} --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/...
 
     # TODO collect used docker images and compare with known list. This list can be used to preload the images into kind
     # TODO  `kind export logs` and look for "ImageCreate" in containerd.log

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -1,0 +1,51 @@
+# When running the end-to-end tests, an istio-operator docker image is built from the local
+# source, then loaded into the kind cluster as `banzaicloud/istio-operator:${E2E_TEST_TAG}`.
+# The reason for using this variable instead of `TAG` is to make sure the pod isn't showing
+# a released version tag (the `TAG` variable defaults to the latest released version).
+# Without this variable, the installed istio-operator pod would contain something like
+# `image: banzaicloud/istio-operator:0.9.3`, but it would _not_ be running the 0.9.3 version
+# of istio-operator. On the other hand, if for some reason the image is not loaded into the
+# cluster before installing the istio-operator, the `banzaicloud/istio-operator:0.9.3` image
+# would be pulled down and started, which wouldn't be the expected image.
+# To avoid this and similar issues, the tag is forced to be some other value: `e2e-test` by
+# default, or the current branch name on the CI.
+# Currently, it's not possible to run the tests with a different istio-operator version.
+E2E_TEST_TAG ?= e2e-test
+
+.PHONY: e2e-test-dependencies
+e2e-test-dependencies:
+	./scripts/e2e-test/download-deps.sh
+
+.PHONY: e2e-test-env
+e2e-test-env: e2e-test-dependencies
+	# There's an issue (https://github.com/banzaicloud/istio-operator/issues/643) with resource cleanup on
+	# k8s 1.20, so running the tests on 1.19.7 for now
+	env PATH=./bin:$${PATH} ./scripts/e2e-test/setup-env.sh 1.19.7 ${ISTIO_VERSION}
+
+.PHONY: e2e-test-install-istio-operator
+e2e-test-install-istio-operator: export PATH:=./bin:${PATH}
+e2e-test-install-istio-operator: TAG=${E2E_TEST_TAG}
+e2e-test-install-istio-operator: docker-build
+	# TODO build with TEST_RACE_DETECTOR=1 in docker-build
+	kind load docker-image ${IMG}
+	helm install --wait \
+		--set operator.image.repository=${IMAGE_REPOSITORY} \
+		--set operator.image.tag=${TAG} \
+		--create-namespace \
+		--namespace istio-system \
+		istio-operator-e2e-test \
+		deploy/charts/istio-operator/
+
+	# Wait for all pods to be ready. `helm --wait` only waits for the pods installed by helm. Usually,
+	# when the istio-operator is ready, a couple of pods in kube-system are still just starting up. It
+	# works out fine now, probably because there is a wait in TestMain for the cluster to be reachable.
+	# Waiting here for all pods might result in a lower load on the cluster when the actual tests
+	# start, so it might remove some flakiness.
+	kubectl wait pod --all-namespaces --all --for=condition=ready --timeout=60s
+
+.PHONY: e2e-test
+e2e-test: download-deps e2e-test-install-istio-operator
+	bin/ginkgo --failFast --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/...
+
+    # TODO collect used docker images and compare with known list. This list can be used to preload the images into kind
+    # TODO  `kind export logs` and look for "ImageCreate" in containerd.log

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -12,6 +12,8 @@
 # Currently, it's not possible to run the tests with a different istio-operator version.
 E2E_TEST_TAG ?= e2e-test
 
+E2E_LOG_DIR ?= ${PWD}/logs
+
 E2E_TEST_FAIL_FAST ?= 0
 
 ifeq (${E2E_TEST_FAIL_FAST}, 1)
@@ -51,8 +53,11 @@ e2e-test-install-istio-operator: docker-build
 
 .PHONY: e2e-test
 e2e-test: download-deps e2e-test-install-istio-operator
-	env E2E_TEST_FAIL_FAST=${E2E_TEST_FAIL_FAST} \
-		bin/ginkgo ${E2E_TEST_GINKGO_ARGS} --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/...
+	mkdir -p ${E2E_LOG_DIR}
+	env E2E_TEST_FAIL_FAST=${E2E_TEST_FAIL_FAST} E2E_LOG_DIR=${E2E_LOG_DIR} \
+		E2E_TEST_DUMP_SCRIPT=${PWD}/scripts/dump-cluster-state-and-logs.sh \
+		bin/ginkgo ${E2E_TEST_GINKGO_ARGS} --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/... \
+			| tee ${E2E_LOG_DIR}/e2e-test.log
 
     # TODO collect used docker images and compare with known list. This list can be used to preload the images into kind
     # TODO  `kind export logs` and look for "ImageCreate" in containerd.log

--- a/test/e2e/e2e_helpers_test.go
+++ b/test/e2e/e2e_helpers_test.go
@@ -354,6 +354,7 @@ func clusterIsClean(before ClusterResourceList, after ClusterResourceList) bool 
 
 // TODO add more resource types
 func listAllResources(d dynamic.Interface) (ClusterResourceList, error) {
+	// This list should probably match the list in dump-cluster-state-and-logs.sh
 	gvrs := []schema.GroupVersionResource{
 		gvr.Service,
 		gvr.Pod,

--- a/test/e2e/e2e_helpers_test.go
+++ b/test/e2e/e2e_helpers_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -49,6 +50,18 @@ import (
 
 func getLoggerName(gtd ginkgo.GinkgoTestDescription) string {
 	return strings.Join(gtd.ComponentTexts, "/")
+}
+
+func shouldFailFast() bool {
+	return os.Getenv("E2E_TEST_FAIL_FAST") == "1"
+}
+
+func maybeCleanup(log logr.Logger, noCleanupMsg string, cleanup func()) {
+	if shouldFailFast() && ginkgo.CurrentGinkgoTestDescription().Failed {
+		log.Info(noCleanupMsg)
+	} else {
+		cleanup()
+	}
 }
 
 type IstioTestEnv struct {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -28,26 +28,32 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 
 	"github.com/banzaicloud/istio-operator/pkg/util"
+	"github.com/banzaicloud/istio-operator/test/e2e/util/clusterstate"
 )
 
 type TestEnv struct {
 	Log     logr.Logger
 	Client  client.Client
 	Dynamic dynamic.Interface
+
+	ClusterStateDumper *clusterstate.Dumper
 }
 
 func NewTestEnv() *TestEnv {
-	logf.SetLogger(util.CreateLogger(true, true))
 	log := logf.Log.WithName("TestSuite")
 
 	return &TestEnv{
 		Log: log,
 		Client:  getClient(),
 		Dynamic: getDynamicClient(),
+
+		ClusterStateDumper: clusterstate.NewDumper(log),
 	}
 }
 
 func TestE2E(t *testing.T) {
+	logf.SetLogger(util.CreateLogger(true, true))
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "E2E Suite")
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -56,6 +56,8 @@ var _ = Describe("E2E", func() {
 		istioTestEnv.WaitForIstioReconcile()
 	})
 
+	JustAfterEach(func() {testEnv.ClusterStateDumper.Dump(CurrentGinkgoTestDescription())})
+
 	AfterEach(func() {
 		maybeCleanup(log, "Test failed, not waiting for cleanup", func() {
 			istioTestEnv.Close()

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -56,7 +56,13 @@ var _ = Describe("E2E", func() {
 		istioTestEnv.WaitForIstioReconcile()
 	})
 
-	JustAfterEach(func() {testEnv.ClusterStateDumper.Dump(CurrentGinkgoTestDescription())})
+	// TODO Move this out of this "Describe" somehow. It should automatically run after all failed tests, not just the
+	//  ones in this "Describe".
+	JustAfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			testEnv.ClusterStateDumper.Dump(CurrentGinkgoTestDescription())
+		}
+	})
 
 	AfterEach(func() {
 		maybeCleanup(log, "Test failed, not waiting for cleanup", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -57,12 +57,10 @@ var _ = Describe("E2E", func() {
 	})
 
 	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			log.Info("Test failed, not waiting for cleanup")
-		} else {
+		maybeCleanup(log, "Test failed, not waiting for cleanup", func() {
 			istioTestEnv.Close()
 			WaitForCleanup(log, clusterStateBeforeTests, 60*time.Second, 100*time.Millisecond)
-		}
+		})
 	})
 
 	Describe("tests with minimal istio resource", func() {
@@ -96,11 +94,9 @@ var _ = Describe("E2E", func() {
 			})
 
 			AfterEach(func() {
-				if CurrentGinkgoTestDescription().Failed {
-					log.Info("Test failed, not cleaning up")
-				} else {
+				maybeCleanup(log, "Test failed, not cleaning up", func() {
 					Expect(resources.DeleteResources(testEnv.Client, resourcesFile)).To(Succeed())
-				}
+				})
 			})
 
 			It("sets up working ingress", func() {

--- a/test/e2e/util/clusterstate/dump.go
+++ b/test/e2e/util/clusterstate/dump.go
@@ -1,0 +1,65 @@
+package clusterstate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-logr/logr"
+	"github.com/onsi/ginkgo"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+
+	"github.com/banzaicloud/istio-operator/test/e2e/util"
+)
+
+type Dumper struct {
+	log logr.Logger
+	dumpDir string
+}
+
+const defaultLogDir = "logs"
+
+func NewDumper(log logr.Logger) *Dumper {
+	return &Dumper{
+		log:     log,
+		dumpDir: getDumpDir(log),
+	}
+}
+
+func (d Dumper) Dump(currentTest ginkgo.GinkgoTestDescription) {
+	testDumpDir := filepath.Join(append([]string{d.dumpDir}, currentTest.ComponentTexts...)...)
+	d.log.Info("Dumping cluster state and logs", "dir", testDumpDir)
+
+	err := dump(d.log, testDumpDir)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func getDumpDir(log logr.Logger) string {
+	dumpDir := os.Getenv("E2E_LOG_DIR")
+	if dumpDir == "" {
+		logf.Log.Info(fmt.Sprintf("Env variable E2E_LOG_DIR is not set. Using \"%s\" as log dir", defaultLogDir))
+		dumpDir = defaultLogDir
+	}
+	dumpDir, err := filepath.Abs(dumpDir)
+	if err != nil {
+		panic(err)
+	}
+	log.Info(fmt.Sprintf("Log dir: %s", dumpDir))
+	return dumpDir
+}
+
+func dump(log logr.Logger, dir string) error {
+	script := os.Getenv("E2E_TEST_DUMP_SCRIPT")
+	command := fmt.Sprintf("%s \"%s\"", script, dir)
+	stdout, stderr, err := util.RunInShell(command)
+	if err != nil {
+		log.Error(err, "Failed to dump cluster state and logs. Stderr and stdout follows", "command", command)
+		log.Info("stderr:\n" + stderr.String())
+		log.Info("stdout:\n" + stdout.String())
+		return err
+	}
+
+	return nil
+}

--- a/test/e2e/util/clusterstate/dump.go
+++ b/test/e2e/util/clusterstate/dump.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package clusterstate
 
 import (

--- a/test/e2e/util/exec.go
+++ b/test/e2e/util/exec.go
@@ -1,0 +1,16 @@
+package util
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+func RunInShell(command string) (bytes.Buffer, bytes.Buffer, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := exec.Command("bash", "-c", command)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout, stderr, err
+}

--- a/test/e2e/util/exec.go
+++ b/test/e2e/util/exec.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 Banzai Cloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?

Basic log and cluster state collection for end-to-end tests. When a test fails, it collects all logs and relevant resources from the
cluster and stores it under a directory named after the test. On the CI the collected info is compressed and uploaded to the CI storage for later inspection.

An example failure: https://app.circleci.com/pipelines/github/banzaicloud/istio-operator/2079/workflows/13fc08a4-b310-4614-9b0d-a0a7e81f45a2/jobs/3900
The logs can be found on the "Artifacts" tab.

### Checklist

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
