### PR TITLE
support federated multi with upstream pilot and proxy

### DIFF
--- a/docs/federation/gateway/samples/istio-multicluster-cr.yaml
+++ b/docs/federation/gateway/samples/istio-multicluster-cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: istio-gw-multi
 spec:
   version: "1.9.5"
-  global: false
+  global: true
   meshPolicy:
     mtlsMode: STRICT
   meshExpansion: true


### PR DESCRIPTION
### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- removes cert fetcher container from sidecar injector deployment since versions 1.9.4+ have builtin support for webhook cert generation.
- changes federated multi docs control plane CR to global to make it work with upstream pilot as well
