### PR TITLE
fix deepcopy generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ endif
 # Generate code
 generate: download-deps update-istio-deps
 	cd build && ../bin/buf generate --path api
-	bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	cd api/v1alpha1 && ../../bin/controller-gen object:headerFile="../../hack/boilerplate.go.txt" paths="./..."
 
 # Check that code generation was checked in to git
 check-generate: generate

--- a/api/go.mod
+++ b/api/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/gogo/protobuf v1.3.2
 	istio.io/api v0.0.0-20210420153121-f5a13670bedf
+	istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f
 	k8s.io/apimachinery v0.20.2
 	sigs.k8s.io/controller-runtime v0.6.5
 )


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixes deepcopy generation for api.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

the API was moved to a separate go module so the controller-gen must be running accordingly.
