### PR TITLE
Test Mixerless Telemetry filter adding and removal

### DIFF
--- a/test/e2e/e2e_helpers_test.go
+++ b/test/e2e/e2e_helpers_test.go
@@ -426,21 +426,21 @@ func testDataPath(description ginkgo.GinkgoTestDescription) string {
 	return strings.ReplaceAll(path, " ", "_")
 }
 
-func GetIstioObject(istio *istiov1beta1.Istio, namespace, name string) error {
+func getIstioObject(istio *istiov1beta1.Istio, namespace, name string) error {
 	return testEnv.Client.Get(context.TODO(), client.ObjectKey{
 		Namespace: namespace,
 		Name:      name},
 		istio)
 }
 
-func SetMixerlessTelemetryState(istio *istiov1beta1.Istio, newState *bool) error {
+func setMixerlessTelemetryState(istio *istiov1beta1.Istio, newState *bool) error {
 	istio.Spec.MixerlessTelemetry.Enabled = newState
 	// upload to cluster
 	testEnv.Log.Info("Updating cluster to:", "newState", newState)
 	return testEnv.Client.Update(context.TODO(), istio)
 }
 
-func WaitForMixerlessTelemetryFilter(
+func waitForMixerlessTelemetryFilter(
 	namespace, filterName string, filterShouldExist bool, timeout, interval time.Duration) error {
 	return util.WaitForCondition(timeout, interval, func() (bool, error) {
 		_, err := testEnv.Dynamic.Resource(gvr.EnvoyFilter).Namespace(namespace).Get(
@@ -460,12 +460,12 @@ func WaitForMixerlessTelemetryFilter(
 	})
 }
 
-func WaitForMixerlessTelemetryFilters(
+func waitForMixerlessTelemetryFilters(
 	namespace, filterName1 string, filterName2 string, filterShouldExist bool, timeout, interval time.Duration) error {
 	// check both filters sequentially. Usually, the first filter will wait the most.
-	err := WaitForMixerlessTelemetryFilter(namespace, filterName1, filterShouldExist, timeout, interval)
+	err := waitForMixerlessTelemetryFilter(namespace, filterName1, filterShouldExist, timeout, interval)
 	if err != nil {
 		return err
 	}
-	return WaitForMixerlessTelemetryFilter(namespace, filterName2, filterShouldExist, timeout, interval)
+	return waitForMixerlessTelemetryFilter(namespace, filterName2, filterShouldExist, timeout, interval)
 }

--- a/test/e2e/e2e_helpers_test.go
+++ b/test/e2e/e2e_helpers_test.go
@@ -433,15 +433,6 @@ func GetIstioObject(istio *istiov1beta1.Istio, namespace, name string) error {
 		istio)
 }
 
-func GetMixerlessTelemetryStatus(istio *istiov1beta1.Istio, namespace, name string) (*bool, error) {
-	err := GetIstioObject(istio, namespace, name)
-	if err != nil {
-		return nil, err
-	}
-	// query current state and return it
-	return istio.Spec.MixerlessTelemetry.Enabled, nil
-}
-
 func SetMixerlessTelemetryState(istio *istiov1beta1.Istio, newState *bool) error {
 	istio.Spec.MixerlessTelemetry.Enabled = newState
 	// upload to cluster

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,9 +19,8 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"strings"
 	"path/filepath"
-	"runtime"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -132,6 +131,7 @@ var _ = Describe("E2E", func() {
 						log.Info("AfterEach: Restore", "filterBefore", filterBefore, "filterNow", filterNow)
 						expectMissingFilter, err = SetMixerlessTelemetryState(
 							&istio, instance.Namespace, instance.Name, filterBefore)
+						Expect(err).NotTo(HaveOccurred())
 						err = WaitForMixerlessTelemetryFilter(
 							istio.Namespace, statsname, expectMissingFilter, 300*time.Second, 5*time.Second)
 						Expect(err).NotTo(HaveOccurred())
@@ -167,6 +167,7 @@ var _ = Describe("E2E", func() {
 				for i, state := range stateTransitions {
 					expectMissingFilter, err = SetMixerlessTelemetryState(
 						&istio, instance.Namespace, instance.Name, string(state))
+					Expect(err).NotTo(HaveOccurred())
 					if state == 'F' && previousState == "N" {
 						time.Sleep(15 * time.Second)
 					}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -102,47 +102,47 @@ var _ = Describe("E2E", func() {
 				// get the istio object created in the OUTER JustBeforeEach
 				log.Info("Namespace: ", "Namespace", instance.Namespace)
 				log.Info("Name: ", "Name", instance.Name)
-				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(getIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
 				version := istio.Spec.Version // get first 2 digits
 				versionParts := strings.SplitN(string(version), ".", 3)
 				majorMinor = fmt.Sprintf("%s.%s", versionParts[0], versionParts[1])
 				log.Info("Istio Version: ", "Version", majorMinor)
 			})
 
-			It("Transitions Filter through all states", func() {
+			It("Sets Filter to each state and restores to True", func() {
 				// Names of the filters of interest
 				statsName := istio.WithRevision(fmt.Sprintf("mixerless-telemetry-stats-filter-%s", majorMinor))
 				tcpName := istio.WithRevision(fmt.Sprintf("mixerless-telemetry-tcp-stats-filter-%s", majorMinor))
 				log.Info("Filter Names: ", "Stats", statsName, "TCP", tcpName)
 
 				log.Info("Starting filter as true")
-				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
-				Expect(SetMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
-				Expect(WaitForMixerlessTelemetryFilters(
+				Expect(getIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(setMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
+				Expect(waitForMixerlessTelemetryFilters(
 					istio.Namespace, statsName, tcpName, true, timeout, interval)).Should(Succeed())
 
-				log.Info("Transition filter true -> false")
-				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
-				Expect(SetMixerlessTelemetryState(&istio, util.BoolPointer(false))).Should(Succeed())
-				Expect(WaitForMixerlessTelemetryFilters(
+				log.Info("Set filter to false")
+				Expect(getIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(setMixerlessTelemetryState(&istio, util.BoolPointer(false))).Should(Succeed())
+				Expect(waitForMixerlessTelemetryFilters(
 					istio.Namespace, statsName, tcpName, false, timeout, interval)).Should(Succeed())
 
-				log.Info("Transition filter false -> true")
-				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
-				Expect(SetMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
-				Expect(WaitForMixerlessTelemetryFilters(
+				log.Info("Restore filter false -> true")
+				Expect(getIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(setMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
+				Expect(waitForMixerlessTelemetryFilters(
 					istio.Namespace, statsName, tcpName, true, timeout, interval)).Should(Succeed())
 
-				log.Info("Transition filter true -> nil")
-				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
-				Expect(SetMixerlessTelemetryState(&istio, nil)).Should(Succeed())
-				Expect(WaitForMixerlessTelemetryFilters(
+				log.Info("Set filter to nil")
+				Expect(getIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(setMixerlessTelemetryState(&istio, nil)).Should(Succeed())
+				Expect(waitForMixerlessTelemetryFilters(
 					istio.Namespace, statsName, tcpName, false, timeout, interval)).Should(Succeed())
 
-				log.Info("Transition filter nil -> true")
-				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
-				Expect(SetMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
-				Expect(WaitForMixerlessTelemetryFilters(
+				log.Info("Restore filter nil -> true")
+				Expect(getIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(setMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
+				Expect(waitForMixerlessTelemetryFilters(
 					istio.Namespace, statsName, tcpName, true, timeout, interval)).Should(Succeed())
 
 			})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -93,8 +93,6 @@ var _ = Describe("E2E", func() {
 			// var resourcesFile string
 			var (
 				istio        v1beta1.Istio
-				filterBefore *bool
-				err          error
 				majorMinor   string
 			)
 			const timeout = 30 * time.Second
@@ -104,28 +102,11 @@ var _ = Describe("E2E", func() {
 				// get the istio object created in the OUTER JustBeforeEach
 				log.Info("Namespace: ", "Namespace", instance.Namespace)
 				log.Info("Name: ", "Name", instance.Name)
-				filterBefore, err = GetMixerlessTelemetryStatus(&istio, instance.Namespace, instance.Name)
-				Expect(err).NotTo(HaveOccurred())
-				log.Info("JustBeforeEach: ", "filterBefore", filterBefore)
+				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
 				version := istio.Spec.Version // get first 2 digits
 				versionParts := strings.SplitN(string(version), ".", 3)
 				majorMinor = fmt.Sprintf("%s.%s", versionParts[0], versionParts[1])
 				log.Info("Istio Version: ", "Version", majorMinor)
-
-			})
-
-			AfterEach(func() {
-				var filterNow *bool
-				filterNow, err = GetMixerlessTelemetryStatus(&istio, instance.Namespace, instance.Name)
-				Expect(err).NotTo(HaveOccurred())
-				// Only change back if filterBefore != filterNow
-				// complicated by the ability of the *bool to be nil
-				if (filterNow == nil && filterBefore != nil) || (filterNow != nil && filterBefore == nil) || (
-					filterNow != nil && filterBefore != nil && *filterNow != *filterBefore) {
-					log.Info("AfterEach: Restore", "filterBefore", filterBefore, "filterNow", filterNow)
-					err = SetMixerlessTelemetryState(&istio, filterBefore)
-					Expect(err).NotTo(HaveOccurred())
-				}
 			})
 
 			It("Transitions Filter through all states", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -97,10 +97,8 @@ var _ = Describe("E2E", func() {
 				err          error
 				majorMinor   string
 			)
-
-			BeforeEach(func() {
-				//
-			})
+			const timeout = 30 * time.Second
+			const interval = 1 * time.Second
 
 			JustBeforeEach(func() {
 				// get the istio object created in the OUTER JustBeforeEach
@@ -137,69 +135,34 @@ var _ = Describe("E2E", func() {
 				log.Info("Filter Names: ", "Stats", statsName, "TCP", tcpName)
 
 				log.Info("Starting filter as true")
-				err := GetIstioObject(&istio, instance.Namespace, instance.Name)
-				Expect(err).NotTo(HaveOccurred())
-				err = SetMixerlessTelemetryState(&istio, util.BoolPointer(true))
-				Expect(err).NotTo(HaveOccurred())
-				// make sure change was applied or removed (loop)
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, statsName, false, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, tcpName, false, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(SetMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
+				Expect(WaitForMixerlessTelemetryFilters(
+					istio.Namespace, statsName, tcpName, true, timeout, interval)).Should(Succeed())
 
 				log.Info("Transition filter true -> false")
-				err = GetIstioObject(&istio, instance.Namespace, instance.Name)
-				Expect(err).NotTo(HaveOccurred())
-				err = SetMixerlessTelemetryState(&istio, util.BoolPointer(false))
-				Expect(err).NotTo(HaveOccurred())
-				// make sure change was applied or removed (loop)
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, statsName, true, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, tcpName, true, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(SetMixerlessTelemetryState(&istio, util.BoolPointer(false))).Should(Succeed())
+				Expect(WaitForMixerlessTelemetryFilters(
+					istio.Namespace, statsName, tcpName, false, timeout, interval)).Should(Succeed())
 
 				log.Info("Transition filter false -> true")
-				err = GetIstioObject(&istio, instance.Namespace, instance.Name)
-				Expect(err).NotTo(HaveOccurred())
-				err = SetMixerlessTelemetryState(&istio, util.BoolPointer(true))
-				Expect(err).NotTo(HaveOccurred())
-				// make sure change was applied or removed (loop)
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, statsName, false, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, tcpName, false, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(SetMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
+				Expect(WaitForMixerlessTelemetryFilters(
+					istio.Namespace, statsName, tcpName, true, timeout, interval)).Should(Succeed())
 
 				log.Info("Transition filter true -> nil")
-				err = GetIstioObject(&istio, instance.Namespace, instance.Name)
-				Expect(err).NotTo(HaveOccurred())
-				err = SetMixerlessTelemetryState(&istio, nil)
-				Expect(err).NotTo(HaveOccurred())
-				// make sure change was applied or removed (loop)
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, statsName, true, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, tcpName, true, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(SetMixerlessTelemetryState(&istio, nil)).Should(Succeed())
+				Expect(WaitForMixerlessTelemetryFilters(
+					istio.Namespace, statsName, tcpName, false, timeout, interval)).Should(Succeed())
 
 				log.Info("Transition filter nil -> true")
-				err = GetIstioObject(&istio, instance.Namespace, instance.Name)
-				Expect(err).NotTo(HaveOccurred())
-				err = SetMixerlessTelemetryState(&istio, util.BoolPointer(true))
-				Expect(err).NotTo(HaveOccurred())
-				// make sure change was applied or removed (loop)
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, statsName, false, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
-				err = WaitForMixerlessTelemetryFilter(
-					istio.Namespace, tcpName, false, 300*time.Second, 5*time.Second)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(GetIstioObject(&istio, instance.Namespace, instance.Name)).Should(Succeed())
+				Expect(SetMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
+				Expect(WaitForMixerlessTelemetryFilters(
+					istio.Namespace, statsName, tcpName, true, timeout, interval)).Should(Succeed())
 
 			})
 		})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	//	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -159,11 +158,11 @@ var _ = Describe("E2E", func() {
 				// based on our starting value filterBefore
 				switch filterBefore {
 				case "T": // beginning state is true
-					stateTransitions = "FNTNFT"
+					stateTransitions = "FTNT"
 				case "F": // beginning state is false
-					stateTransitions = "TFNTNF"
+					stateTransitions = "TFTN"
 				case "N": // beginning state is nil
-					stateTransitions = "TNFTFN"
+					stateTransitions = "TFTN"
 				}
 				for i, state := range stateTransitions {
 					expectMissingFilter, err = SetMixerlessTelemetryState(

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"fmt"
-	"github.com/banzaicloud/istio-operator/pkg/util"
 	"path/filepath"
 	"strings"
 	"time"
@@ -28,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/banzaicloud/istio-operator/pkg/apis/istio/v1beta1"
+	"github.com/banzaicloud/istio-operator/pkg/util"
 	"github.com/banzaicloud/istio-operator/test/e2e/util/resources"
 )
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -90,7 +90,6 @@ var _ = Describe("E2E", func() {
 			})
 		})
 		Context("Mixerless Telemetry Stats Filter Test", func() {
-			// var resourcesFile string
 			var (
 				istio        v1beta1.Istio
 				majorMinor   string


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
Adds End to End testing for Enabling and disabling Mixerless Telemetry Filters

### Why?
Adding E2E tests
An email was wrong in git, so this PR replaces 
https://github.com/banzaicloud/istio-operator/pull/662

### Checklist
- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

