### PR TITLE
WIP: Make MetalLB work on MacOS for end-to-end tests

### DIFF
--- a/scripts/download-deps.sh
+++ b/scripts/download-deps.sh
@@ -10,6 +10,8 @@ yq_version=3.4.0
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 binpath=${script_dir}/../bin
 
+mkdir -p "${binpath}"
+
 function ensure-binary-version() {
     local bin_name=$1
     local bin_version=$2

--- a/test/e2e/Dockerfile
+++ b/test/e2e/Dockerfile
@@ -1,0 +1,34 @@
+# This is for running the tests in a docker container which is useful on non-linux systems where MetalLB
+# in effectively non-functional
+
+ARG GO_VERSION=1.13.9
+
+# Build the manager binary
+FROM golang:${GO_VERSION}-alpine3.11
+
+RUN apk add --update --no-cache make~=4.2 git~=2.24 bash~=5 gcc~=9.3 musl-dev
+
+ENV PACKAGE=github.com/banzaicloud/istio-operator
+ENV WORKDIR=/go/src/${PACKAGE}
+RUN mkdir -p ${WORKDIR}
+WORKDIR ${WORKDIR}
+
+ENV E2E_TEST_FAIL_FAST=0
+ENV E2E_LOG_DIR=/logs
+ENV E2E_TEST_GINKGO_ARGS=""
+
+VOLUME ${E2E_LOG_DIR}
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY pkg/    pkg/
+COPY cmd/    cmd/
+COPY Makefile ./
+COPY scripts/ scripts/
+COPY test/ test/
+RUN make vendor
+
+RUN make download-deps
+
+CMD make e2e-test-run

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -51,9 +51,12 @@ e2e-test-install-istio-operator: docker-build
 	# start, so it might remove some flakiness.
 	kubectl wait pod --all-namespaces --all --for=condition=ready --timeout=60s
 
-.PHONY: e2e-test
-e2e-test: download-deps e2e-test-install-istio-operator
+.PHONY: e2e-test-run
+e2e-test-run:
 	env E2E_TEST_FAIL_FAST=${E2E_TEST_FAIL_FAST} \
 		E2E_LOG_DIR=${E2E_LOG_DIR} \
 		E2E_TEST_DUMP_SCRIPT=${PWD}/scripts/dump-cluster-state-and-logs.sh \
 			./test/e2e/scripts/run-tests.sh
+
+.PHONY: e2e-test
+e2e-test: download-deps e2e-test-install-istio-operator e2e-test-run

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -53,11 +53,7 @@ e2e-test-install-istio-operator: docker-build
 
 .PHONY: e2e-test
 e2e-test: download-deps e2e-test-install-istio-operator
-	mkdir -p ${E2E_LOG_DIR}
-	env E2E_TEST_FAIL_FAST=${E2E_TEST_FAIL_FAST} E2E_LOG_DIR=${E2E_LOG_DIR} \
+	env E2E_TEST_FAIL_FAST=${E2E_TEST_FAIL_FAST} \
+		E2E_LOG_DIR=${E2E_LOG_DIR} \
 		E2E_TEST_DUMP_SCRIPT=${PWD}/scripts/dump-cluster-state-and-logs.sh \
-		bin/ginkgo ${E2E_TEST_GINKGO_ARGS} --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/... \
-			| tee ${E2E_LOG_DIR}/e2e-test.log
-
-    # TODO collect used docker images and compare with known list. This list can be used to preload the images into kind
-    # TODO  `kind export logs` and look for "ImageCreate" in containerd.log
+			./test/e2e/scripts/run-tests.sh

--- a/test/e2e/e2e-test.mk
+++ b/test/e2e/e2e-test.mk
@@ -22,13 +22,13 @@ endif
 
 .PHONY: e2e-test-dependencies
 e2e-test-dependencies:
-	./scripts/e2e-test/download-deps.sh
+	./test/e2e/scripts/download-deps.sh
 
 .PHONY: e2e-test-env
 e2e-test-env: e2e-test-dependencies
 	# There's an issue (https://github.com/banzaicloud/istio-operator/issues/643) with resource cleanup on
 	# k8s 1.20, so running the tests on 1.19.7 for now
-	env PATH=./bin:$${PATH} ./scripts/e2e-test/setup-env.sh 1.19.7 ${ISTIO_VERSION}
+	./test/e2e/scripts/setup-env.sh 1.19.7 ${ISTIO_VERSION}
 
 .PHONY: e2e-test-install-istio-operator
 e2e-test-install-istio-operator: export PATH:=./bin:${PATH}

--- a/test/e2e/scripts/download-deps.sh
+++ b/test/e2e/scripts/download-deps.sh
@@ -7,8 +7,8 @@ readonly HELM_VERSION=3.2.3
 readonly KIND_VERSION=0.10.0
 
 readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-readonly scripts_dir=${script_dir}/..
-readonly bin_path=${scripts_dir}/../bin
+readonly repo_root=${script_dir}/../../../
+readonly bin_path=${repo_root}/bin
 
 mkdir -p "${bin_path}"
 

--- a/test/e2e/scripts/run-tests.sh
+++ b/test/e2e/scripts/run-tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+readonly repo_root=${script_dir}/../../..
+
+export PATH=${repo_root}/bin:${PATH}
+
+readonly log_dir=${E2E_LOG_DIR:-${PWD}/logs}
+readonly fail_fast=${E2E_TEST_FAIL_FAST:-0}
+readonly ginkgo_args=${E2E_TEST_GINKGO_ARGS:-}
+
+mkdir -p "${log_dir}"
+env E2E_TEST_FAIL_FAST="${fail_fast}" \
+    E2E_LOG_DIR="${log_dir}" \
+    E2E_TEST_DUMP_SCRIPT="${repo_root}"/scripts/dump-cluster-state-and-logs.sh \
+    ginkgo "${ginkgo_args}" --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/... \
+        | tee "${log_dir}"/e2e-test.log
+
+# TODO collect used docker images and compare with known list. This list can be used to preload the images into kind
+# TODO  `kind export logs` and look for "ImageCreate" in containerd.log

--- a/test/e2e/scripts/run-tests.sh
+++ b/test/e2e/scripts/run-tests.sh
@@ -11,12 +11,55 @@ readonly log_dir=${E2E_LOG_DIR:-${PWD}/logs}
 readonly fail_fast=${E2E_TEST_FAIL_FAST:-0}
 readonly ginkgo_args=${E2E_TEST_GINKGO_ARGS:-}
 
+# Mostly for testing the "in docker way" on Linux
+readonly force_run_in_docker=${E2E_TEST_FORCE_RUN_IN_DOCKER:-0}
+
 mkdir -p "${log_dir}"
-env E2E_TEST_FAIL_FAST="${fail_fast}" \
-    E2E_LOG_DIR="${log_dir}" \
-    E2E_TEST_DUMP_SCRIPT="${repo_root}"/scripts/dump-cluster-state-and-logs.sh \
-    ginkgo "${ginkgo_args}" --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/... \
-        | tee "${log_dir}"/e2e-test.log
+
+function run-tests-directly() {
+    echo "Running tests directly"
+    env E2E_TEST_FAIL_FAST="${fail_fast}" \
+        E2E_LOG_DIR="${log_dir}" \
+        E2E_TEST_DUMP_SCRIPT="${repo_root}"/scripts/dump-cluster-state-and-logs.sh \
+        ginkgo "${ginkgo_args}" --randomizeSuites --randomizeAllSpecs --timeout 10m -v ./test/e2e/... \
+            | tee "${log_dir}"/e2e-test.log
+}
+
+function run-tests-in-docker() {
+    # this doesn't work at the moment. Two kind of connections are necessary for the tests:
+    # 1. kind needs to be accessible. This works from the host machine, and it's probably accessible from a docker
+    #    container too, but I'm not sure how to make it work.
+    # 2. the IP range MetalLB is using needs to be accessible. This only works inside docker on the "kind" network.
+    #    Note: there are "solutions" to make it accessible from the host machine, but what I've seen are ugly hacks
+    #    which are not scriptable.
+    echo "Running tests in docker container"
+
+    local tmpdir
+    tmpdir=$(mktemp -d)
+
+    # KUBECONFIG can contain multiple paths which makes it hard to share the referenced files with the docker container.
+    # To avoid this problem, the kubeconfig is exported into a dir which is then shared with the docker container.
+    kind export kubeconfig --kubeconfig "${tmpdir}"/config.yaml
+
+    docker build -f "${repo_root}"/test/e2e/Dockerfile "${repo_root}" -t istio-operator-e2e-test-runner
+    docker run -t \
+        --network kind \
+        -v "${log_dir}":/logs \
+        -v "${tmpdir}":/kind-config \
+        -e E2E_LOG_DIR="${log_dir}" \
+        -e E2E_TEST_FAIL_FAST="${fail_fast}" \
+        -e E2E_TEST_GINKGO_ARGS="${ginkgo_args}" \
+        -e KUBECONFIG=/kind-config/config.yaml \
+        istio-operator-e2e-test-runner
+
+    rm -r "${tmpdir}"
+}
+
+if [ "$(uname)" != "Linux" ] || [ "${force_run_in_docker}" -eq 1 ]; then
+        run-tests-in-docker
+else
+        run-tests-directly
+fi
 
 # TODO collect used docker images and compare with known list. This list can be used to preload the images into kind
 # TODO  `kind export logs` and look for "ImageCreate" in containerd.log

--- a/test/e2e/scripts/setup-env.sh
+++ b/test/e2e/scripts/setup-env.sh
@@ -13,7 +13,10 @@ if [ -z "${kubernetes_version}" ] || [ -z "${istio_version}" ]; then
 fi
 
 readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-readonly scripts_dir=${script_dir}/..
+readonly repo_root=${script_dir}/../../../
+readonly scripts_dir=${repo_root}/scripts
+
+export PATH=${repo_root}/bin:${PATH}
 
 kind create cluster --image "kindest/node:v${kubernetes_version}"
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?

A stab at making MetalLB work on MacOS, but it doesn't work yet. There is some more information included in the `run-tests-in-docker` function.


### Why?

Without this, the end-to-end tests are not runnable on MacOS. Some of the tests pass, but tests which use a MeshGateway fail because the IPs of the kind cluster are not reachable from the host machine.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] Implementation tested
- [ ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [ ] Logging code meets the guideline
- [ ] User guide and development docs updated (if needed)

### To Do
<!-- (Please remove this section if you don't need it.) -->
- [ ] If the PR is not complete but you want to discuss the approach, list what remains to be done here
