### PR TITLE
Istio test case to validate mesh gateway deployment and service are being created properly

### DIFF
--- a/test/e2e/e2e_helpers_test.go
+++ b/test/e2e/e2e_helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -31,11 +32,14 @@ import (
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
+
 	appsv1 "k8s.io/api/apps/v1"
+
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	k8sapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -108,7 +112,7 @@ func (e *IstioTestEnv) Close() {
 func WaitForCleanup(log logr.Logger, expectedClusterState ClusterResourceList, timeout time.Duration, interval time.Duration) {
 	log.Info("Waiting for cleanup")
 	err := util.WaitForCondition(timeout, interval, func() (bool, error) {
-		currentClusterState, err := listAllResources(testEnv.Dynamic)
+		currentClusterState, err := listAllResources(testEnv.DynamicClient)
 		if err != nil {
 			return false, err
 		}
@@ -117,7 +121,7 @@ func WaitForCleanup(log logr.Logger, expectedClusterState ClusterResourceList, t
 	if err != nil {
 		// The err can be a timeout, in which case it's helpful to show the resources which were not cleaned up
 		log.Error(err, "Got error while waiting for cluster cleanup. Rechecking to give more detail.")
-		clusterStateAfter, err := listAllResources(testEnv.Dynamic)
+		clusterStateAfter, err := listAllResources(testEnv.DynamicClient)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(clusterStateAfter).To(gomega.Equal(expectedClusterState))
 	} else {
@@ -134,7 +138,7 @@ func (e *IstioTestEnv) WaitForIstioReconcile() {
 
 func WaitForStatus(gvr schema.GroupVersionResource, namespace, name string, expectedStatus string, timeout time.Duration, interval time.Duration) error {
 	return util.WaitForCondition(timeout, interval, func() (bool, error) {
-		status, err := GetStatus(context.TODO(), testEnv.Dynamic, gvr, namespace, name)
+		status, err := GetStatus(context.TODO(), testEnv.DynamicClient, gvr, namespace, name)
 		if err != nil {
 			return false, err
 		}
@@ -181,7 +185,7 @@ func GetMeshGatewayAddress(mgw01Namespace string, mgw01Name string, timeout time
 	var meshGatewayAddresses []string
 	err := util.WaitForCondition(timeout, interval, func() (bool, error) {
 		var err error
-		status, err := GetStatus(context.TODO(), testEnv.Dynamic, gvr.MeshGateway, mgw01Namespace, mgw01Name)
+		status, err := GetStatus(context.TODO(), testEnv.DynamicClient, gvr.MeshGateway, mgw01Namespace, mgw01Name)
 		if err != nil {
 			return false, err
 		}
@@ -220,7 +224,7 @@ y:
 	for {
 		select {
 		case <-ticker.C:
-			status, err := GetStatus(context.TODO(), testEnv.Dynamic, gvr.Istio, namespace, name)
+			status, err := GetStatus(context.TODO(), testEnv.DynamicClient, gvr.Istio, namespace, name)
 			if err != nil {
 				return false, err
 			}
@@ -426,4 +430,48 @@ func sortNamespacedNames(nns []types.NamespacedName) {
 func testDataPath(description ginkgo.GinkgoTestDescription) string {
 	path := filepath.Join(description.ComponentTexts...)
 	return strings.ReplaceAll(path, " ", "_")
+}
+
+// Get unstructured object with Kuberentes dynamic clients.
+func GetUnstructuredObject(ctx context.Context, d dynamic.Interface, gvr schema.GroupVersionResource,
+	resource types.NamespacedName) (*unstructured.Unstructured, error){
+	var (
+		unstructuredObject *unstructured.Unstructured
+		err error
+	)
+
+	unstructuredObject, err = d.Resource(gvr).Namespace(resource.Namespace).Get(ctx, resource.Name, metav1.GetOptions{})
+	if err != nil{
+		return nil, err
+	}
+
+	return unstructuredObject, nil
+}
+
+// Get Deployment object with Kuberentes typed clients.
+func GetDeployment(ctx context.Context, c client.Client, resource types.NamespacedName) (*appsv1.Deployment, error){
+	dep := &appsv1.Deployment{}
+
+	err := c.Get(ctx, resource, dep)
+	if err != nil{
+		return dep, err
+	}
+
+	return dep, nil
+}
+
+// Get a container list of given Deployment object.
+func GetContainersFromDeployment(dep *appsv1.Deployment) []corev1.Container{
+	return dep.Spec.Template.Spec.Containers
+}
+
+// Validate if the container exists in given container list.
+func ContainerExists(containerList []corev1.Container, containerName string) error{
+	for _, container := range containerList{
+		if container.Name == containerName{
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%s does not exist in deployment", containerName)
 }

--- a/test/e2e/e2e_helpers_test.go
+++ b/test/e2e/e2e_helpers_test.go
@@ -448,7 +448,7 @@ func GetUnstructuredObject(ctx context.Context, d dynamic.Interface, gvr schema.
 	return unstructuredObject, nil
 }
 
-// Get Deployment object with Kuberentes typed clients.
+// Get Deployment object with Kubernetes typed clients.
 func GetDeployment(ctx context.Context, c client.Client, resource types.NamespacedName) (*appsv1.Deployment, error){
 	dep := &appsv1.Deployment{}
 
@@ -458,6 +458,18 @@ func GetDeployment(ctx context.Context, c client.Client, resource types.Namespac
 	}
 
 	return dep, nil
+}
+
+// Get Service object with Kubernetes typed clients.
+func GetService(ctx context.Context, c client.Client, resource types.NamespacedName) (*corev1.Service, error){
+	svc := &corev1.Service{}
+
+	err := c.Get(ctx, resource, svc)
+	if err != nil{
+		return svc, err
+	}
+
+	return svc, nil
 }
 
 // Get a container list of given Deployment object.

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -33,8 +32,8 @@ import (
 )
 
 type TestEnv struct {
-	Log     logr.Logger
-	Client  client.Client
+	Log           logr.Logger
+	Client        client.Client
 	DynamicClient dynamic.Interface
 
 	ClusterStateDumper *clusterstate.Dumper
@@ -44,8 +43,8 @@ func NewTestEnv() *TestEnv {
 	log := logf.Log.WithName("TestSuite")
 
 	return &TestEnv{
-		Log:     log,
-		Client:  getClient(),
+		Log:           log,
+		Client:        getClient(),
 		DynamicClient: getDynamicClient(),
 
 		ClusterStateDumper: clusterstate.NewDumper(log),

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"k8s.io/client-go/dynamic"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -34,7 +35,7 @@ import (
 type TestEnv struct {
 	Log     logr.Logger
 	Client  client.Client
-	Dynamic dynamic.Interface
+	DynamicClient dynamic.Interface
 
 	ClusterStateDumper *clusterstate.Dumper
 }
@@ -45,7 +46,7 @@ func NewTestEnv() *TestEnv {
 	return &TestEnv{
 		Log:     log,
 		Client:  getClient(),
-		Dynamic: getDynamicClient(),
+		DynamicClient: getDynamicClient(),
 
 		ClusterStateDumper: clusterstate.NewDumper(log),
 	}
@@ -69,14 +70,14 @@ var _ = BeforeSuite(func() {
 	err := waitForClientReady(testEnv.Client, 10*time.Second, 100*time.Millisecond)
 	Expect(err).NotTo(HaveOccurred())
 
-	clusterStateBefore, err = listAllResources(testEnv.Dynamic)
+	clusterStateBefore, err = listAllResources(testEnv.DynamicClient)
 	Expect(err).NotTo(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
 	log := testEnv.Log
 
-	clusterStateAfter, err := listAllResources(testEnv.Dynamic)
+	clusterStateAfter, err := listAllResources(testEnv.DynamicClient)
 	Expect(err).NotTo(HaveOccurred())
 
 	if !clusterIsClean(clusterStateBefore, clusterStateAfter) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -75,7 +75,6 @@ var _ = Describe("E2E", func() {
 	})
 
 	Describe("tests with minimal istio resource", func() {
-		// TODO: Unskipped when creating a PR
 		Context("Istio resource", func() {
 			It("should stay reconciled (Available)", func() {
 				isAvailableConsistently, err := IstioResourceIsAvailableConsistently(log, istioResourceNamespace, istioResourceName, 5*time.Second, 100*time.Millisecond)
@@ -121,7 +120,7 @@ var _ = Describe("E2E", func() {
 					Name:      mgwName,
 				}
 
-				mgwDep, err := WaitForDeployment(istioTestEnv.c, mgwNamespacedName, 300*time.Second, 100*time.Millisecond)
+				mgwDep, err := WaitForDeployment(istioTestEnv.c, mgwNamespacedName, 300*time.Second, 10*time.Second)
 				Expect(err).ShouldNot(HaveOccurred())
 
 				const (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -120,6 +120,7 @@ var _ = Describe("E2E", func() {
 					Name:      mgwName,
 				}
 
+
 				mgwDep, err := WaitForDeployment(istioTestEnv.c, mgwNamespacedName, 300*time.Second, 10*time.Second)
 				Expect(err).ShouldNot(HaveOccurred())
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -120,7 +120,6 @@ var _ = Describe("E2E", func() {
 					Name:      mgwName,
 				}
 
-
 				mgwDep, err := WaitForDeployment(istioTestEnv.c, mgwNamespacedName, 300*time.Second, 10*time.Second)
 				Expect(err).ShouldNot(HaveOccurred())
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | [SMM-190](https://jira-eng-sjc4.cisco.com/jira/browse/SMM-190)
| License         | Apache 2.0


## What's in this PR?
Implementation of test cases to validate: 
- A mesh gateway deployment is being created 
- A mesh gateway service is created that matches the mesh-gateway's name in the same namespace

## Why?
- To validate deployment's name matches the mesh-gateway's name and only istio-proxy sidecar container running inside
- To validate this mesh-gateway service is pointed to the mesh-gateway's deployment
- Make sure all resources being cleaned between each suites and test cases

## Additional context
### Environment Setup
- **KinD** cluster
- **istio-operator** deployed

### Logs and Pictures
- [Gist - Test cases logs](https://gist.github.com/shanchunyang0919/79affe052131a8521821df6f870142b8)
- **Clean up** after running test cases
<img width="890" alt="Screen Shot 2021-06-02 at 8 48 01 PM" src="https://user-images.githubusercontent.com/71080192/120584360-b3b6e600-c3e4-11eb-85cb-4be9c53b4ecd.png">

