### PR TITLE
[v2] Controller enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,59 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases
@@ -15,6 +68,58 @@ rules:
   - get
   - list
   - update
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - envoyfilters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  - podsecuritypolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - security.istio.io
+  resources:
+  - peerauthentications
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - servicemesh.cisco.com
   resources:

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -51,7 +51,15 @@ type IstioControlPlaneReconciler struct {
 	Scheme *runtime.Scheme
 }
 
+// +kubebuilder:rbac:groups="",resources=configmaps;secrets;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations;mutatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="apps",resources=deployments;daemonsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="autoscaling",resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;create;update
+// +kubebuilder:rbac:groups="policy",resources=podsecuritypolicies;poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="security.istio.io",resources=peerauthentications,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="networking.istio.io",resources=envoyfilters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes/status,verbs=get;update;patch
 
@@ -127,18 +135,19 @@ func (r *IstioControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&appsv1.DaemonSet{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&corev1.ConfigMap{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&corev1.Secret{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&corev1.Service{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&corev1.ServiceAccount{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&policyv1beta1.PodSecurityPolicy{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&policyv1beta1.PodDisruptionBudget{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&rbacv1.Role{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&rbacv1.RoleBinding{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&rbacv1.ClusterRole{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&rbacv1.ClusterRoleBinding{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&corev1.Secret{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&istioclientv1alpha3.EnvoyFilter{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&istioclientv1beta1.PeerAuthentication{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&autoscalingv1.HorizontalPodAutoscaler{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&istioclientv1alpha3.EnvoyFilter{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&istioclientv1beta1.PeerAuthentication{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Complete(r)
 }

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -28,6 +28,7 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -131,23 +132,113 @@ func (r *IstioControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 func (r *IstioControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&servicemeshv1alpha1.IstioControlPlane{}).
-		Owns(&appsv1.Deployment{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&appsv1.DaemonSet{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&corev1.ConfigMap{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&corev1.Secret{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&corev1.Service{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&corev1.ServiceAccount{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&policyv1beta1.PodSecurityPolicy{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&policyv1beta1.PodDisruptionBudget{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&rbacv1.Role{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&rbacv1.RoleBinding{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&rbacv1.ClusterRole{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&rbacv1.ClusterRoleBinding{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&autoscalingv1.HorizontalPodAutoscaler{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&istioclientv1alpha3.EnvoyFilter{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
-		Owns(&istioclientv1beta1.PeerAuthentication{}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		For(&servicemeshv1alpha1.IstioControlPlane{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "IstioControlPlane",
+				APIVersion: servicemeshv1alpha1.SchemeBuilder.GroupVersion.String(),
+			},
+		}).
+		Owns(&appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&appsv1.DaemonSet{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "DaemonSet",
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Secret",
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&corev1.Service{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&corev1.ServiceAccount{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ServiceAccount",
+				APIVersion: corev1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&policyv1beta1.PodSecurityPolicy{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PodSecurityPolicy",
+				APIVersion: policyv1beta1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&policyv1beta1.PodDisruptionBudget{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PodDisruptionBudget",
+				APIVersion: policyv1beta1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&rbacv1.Role{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Role",
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&rbacv1.RoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "RoleBinding",
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&rbacv1.ClusterRole{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ClusterRole",
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&rbacv1.ClusterRoleBinding{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ClusterRoleBinding",
+				APIVersion: rbacv1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&autoscalingv1.HorizontalPodAutoscaler{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "HorizontalPodAutoscaler",
+				APIVersion: autoscalingv1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "MutatingWebhookConfiguration",
+				APIVersion: admissionregistrationv1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ValidatingWebhookConfiguration",
+				APIVersion: admissionregistrationv1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&istioclientv1alpha3.EnvoyFilter{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "EnvoyFilter",
+				APIVersion: istioclientv1alpha3.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
+		Owns(&istioclientv1beta1.PeerAuthentication{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PeerAuthentication",
+				APIVersion: istioclientv1beta1.SchemeGroupVersion.String(),
+			},
+		}, ctrlBuilder.WithPredicates(reconciler.SpecChangePredicate{})).
 		Complete(r)
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

1. Add `internal` dir copy to `Dockerfile`
2. Change `ClusterRole` group version
3. Add missing RBAC rules for operator
4. Add TypeMeta to all watched k8s resources

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

1. Docker build failed otherwise
2. `rbac.authorization.k8s.io/v1beta1` is deprecated in favor of `rbac.authorization.k8s.io/v1` starting from k8s 1.17
3.  To be able to watch (and later create/modify) k8s resources (otherwise controller failed to start on a cluster)
4. To see proper kinds and api versions in logs

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

1. Docker build failure:

```
   => ERROR [builder 11/11] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go                                                                                     11.7s
------
 > [builder 11/11] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go:
#18 0.464 go: finding module for package github.com/banzaicloud/istio-operator/v2/internal/components/discovery
#18 0.500 go: finding module for package github.com/banzaicloud/istio-operator/v2/internal/components/base
#18 4.875 go: downloading github.com/banzaicloud/istio-operator v0.0.0-20210603155146-3cf51f7ea68d
#18 11.61 controllers/istiocontrolplane_controller.go:41:2: module github.com/banzaicloud/istio-operator@latest found (v0.0.0-20210603155146-3cf51f7ea68d), but does not contain package github.com/banzaicloud/istio-operator/v2/internal/components/base
#18 11.61 controllers/istiocontrolplane_controller.go:42:2: module github.com/banzaicloud/istio-operator@latest found (v0.0.0-20210603155146-3cf51f7ea68d), but does not contain package github.com/banzaicloud/istio-operator/v2/internal/components/discovery
------
executor failed running [/bin/sh -c CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go]: exit code: 1
make: *** [docker-build] Error 1
```

2. Deprecation warning:

```
Warning: rbac.authorization.k8s.io/v1beta1 ClusterRole is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRole
clusterrole.rbac.authorization.k8s.io/istio-operator-v2-metrics-reader created
```

3.  Without the RBAC rules:

```
E0614 15:50:49.361599       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1.Deployment: failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:istio-system:default" cannot list resource "deployments" in API group "apps" at the cluster scope
```

4. Without TypeMeta settings a lot of lines like this:

```
2021-06-14T17:11:06.297+0200	INFO	controller-runtime.manager.controller.istiocontrolplane	Starting EventSource	{"reconciler group": "servicemesh.cisco.com", "reconciler kind": "IstioControlPlane", "source": "kind source: /, Kind="}
2021-06-14T17:11:06.401+0200	INFO	controller-runtime.manager.controller.istiocontrolplane	Starting EventSource	{"reconciler group": "servicemesh.cisco.com", "reconciler kind": "IstioControlPlane", "source": "kind source: /, Kind="}
2021-06-14T17:11:06.503+0200	INFO	controller-runtime.manager.controller.istiocontrolplane	Starting EventSource	{"reconciler group": "servicemesh.cisco.com", "reconciler kind": "IstioControlPlane", "source": "kind source: /, Kind="}
```

After the TypeMeta settings this starts with:

```
2021-06-14T16:48:44.613Z	INFO	controller-runtime.manager.controller.istiocontrolplane	Starting EventSource	{"reconciler group": "servicemesh.cisco.com", "reconciler kind": "IstioControlPlane", "source": "kind source: servicemesh.cisco.com/v1alpha1, Kind=IstioControlPlane"}
2021-06-14T16:48:45.011Z	INFO	controller-runtime.manager.controller.istiocontrolplane	Starting EventSource	{"reconciler group": "servicemesh.cisco.com", "reconciler kind": "IstioControlPlane", "source": "kind source: apps/v1, Kind=Deployment"}
2021-06-14T16:48:45.215Z	INFO	controller-runtime.manager.controller.istiocontrolplane	Starting EventSource	{"reconciler group": "servicemesh.cisco.com", "reconciler kind": "IstioControlPlane", "source": "kind source: apps/v1, Kind=DaemonSet"}
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
