### PR TITLE
[v2] Convert MeshConfig struct for helm reconciler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/banzaicloud/istio-operator/v2/static v0.0.1
 	github.com/banzaicloud/operator-tools v0.21.2-0.20210422182251-13765652229a
 	github.com/go-logr/logr v0.4.0
+	github.com/golang/protobuf v1.4.3
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 Cisco Systems, Inc. and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+
+	"emperror.dev/errors"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+
+	"github.com/banzaicloud/operator-tools/pkg/helm"
+)
+
+func ProtoFieldToStriMap(protoField proto.Message, striMap *helm.Strimap) error {
+	marshaller := jsonpb.Marshaler{}
+	stringField, err := marshaller.MarshalToString(protoField)
+	if err != nil {
+		return errors.Errorf("proto field cannot be converted into string: %+v", protoField)
+	}
+
+	err = json.Unmarshal([]byte(stringField), striMap)
+	if err != nil {
+		return errors.Errorf("proto field cannot be converted into map[string]interface{}: %+v", protoField)
+	}
+
+	return nil
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Convert `MeshConfig` struct values to `map[string]interface{}` values for the helm reconciler

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

So that the `MeshConfig` field values set in the `IstioControlPlane` CR are reconciled and reflected in the appropriate `istio` `ConfigMap`.

Also, with the conversion way, there is no need to manually set all `MeshConfig` fields manually from the code.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
