### PR TITLE
[v1.9] fix nil annotations in injection template

### DIFF
--- a/pkg/controller/meshgateway/meshgateway_controller.go
+++ b/pkg/controller/meshgateway/meshgateway_controller.go
@@ -121,7 +121,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 func triggerMeshGateways(mgr manager.Manager, object runtime.Object, logger logr.Logger) []reconcile.Request {
 	requests := make([]reconcile.Request, 0)
 
-	istio := &istiov1beta1.Istio{}
+	var istio *istiov1beta1.Istio
 	var ok bool
 	if istio, ok = object.(*istiov1beta1.Istio); !ok {
 		return nil

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -95,8 +95,8 @@ var _ = Describe("E2E", func() {
 		})
 		Context("Mixerless Telemetry Stats Filter Test", func() {
 			var (
-				istio        v1beta1.Istio
-				majorMinor   string
+				istio      v1beta1.Istio
+				majorMinor string
 			)
 			const timeout = 120 * time.Second
 			const interval = 10 * time.Second
@@ -147,7 +147,6 @@ var _ = Describe("E2E", func() {
 				Expect(setMixerlessTelemetryState(&istio, util.BoolPointer(true))).Should(Succeed())
 				Expect(waitForMixerlessTelemetryFilters(
 					istio.Namespace, statsName, tcpName, true, timeout, interval)).Should(Succeed())
-
 			})
 		})
 
@@ -206,7 +205,6 @@ var _ = Describe("E2E", func() {
 					err = containerExists(containerList, istioProxyContainerName)
 					Expect(err).ShouldNot(HaveOccurred())
 				})
-
 			})
 
 			Context("when mgw service is created", func() {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

The injection template contains a bug that removes pod annotations in case of multiple containers in a pod.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

In case of multiple containers the parsed template contains a nil annotation instead of an empty set.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
