### PR TITLE
[v1.10] remove ca root cm cross namespace owner reference

### DIFF
--- a/pkg/remoteclusters/reconcile_ca_root.go
+++ b/pkg/remoteclusters/reconcile_ca_root.go
@@ -33,11 +33,9 @@ const (
 	certKeyInConfigMap  = "root-cert.pem"
 )
 
-var (
-	caRootConfigMapLabels = map[string]string{
-		"banzaicloud.io/managed-by": "istio-operator",
-	}
-)
+var caRootConfigMapLabels = map[string]string{
+	"banzaicloud.io/managed-by": "istio-operator",
+}
 
 func (c *Cluster) reconcileCARootToNamespaces(remoteConfig *istiov1beta1.RemoteIstio, istio *istiov1beta1.Istio) error {
 	desiredState := k8sutil.DesiredStatePresent
@@ -82,13 +80,8 @@ func (c *Cluster) reconcileCARootInNamespace(name, namespace string, configMapDa
 		},
 		Data: configMapData,
 	}
-	ownerRef, err := k8sutil.SetOwnerReferenceToObject(&configmap, c.istioConfig)
-	if err != nil {
-		return err
-	}
-	configmap.SetOwnerReferences(ownerRef)
 
-	err = k8sutil.Reconcile(c.log, c.ctrlRuntimeClient, &configmap, desiredState)
+	err := k8sutil.Reconcile(c.log, c.ctrlRuntimeClient, &configmap, desiredState)
 	if err != nil {
 		return emperror.WrapWith(err, "failed to reconcile resource", "resource", configmap.GetObjectKind().GroupVersionKind())
 	}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Removes cross namespace owner reference from ca root configmap.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Cross namespace owner references are disallowed by design and the gc k8s from v1.20+ aggressively enforces that.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
