### PR TITLE
[v1.10] cleanup components

### DIFF
--- a/pkg/controller/istio/istio_controller.go
+++ b/pkg/controller/istio/istio_controller.go
@@ -298,6 +298,14 @@ func (r *ReconcileIstio) reconcile(logger logr.Logger, config *istiov1beta1.Isti
 					Namespace: config.Namespace,
 				},
 			}, logger)
+			// run cleanups
+			reconcilers := r.getReconcilers(config)
+			for _, rec := range reconcilers {
+				err := rec.Cleanup(logger)
+				if err != nil {
+					return reconcile.Result{}, err
+				}
+			}
 			config.ObjectMeta.Finalizers = util.RemoveString(config.ObjectMeta.Finalizers, finalizerID)
 			if err := r.Update(context.Background(), config); err != nil {
 				return reconcile.Result{}, emperror.Wrap(err, "could not remove finalizer from config")
@@ -342,24 +350,7 @@ func (r *ReconcileIstio) reconcile(logger logr.Logger, config *istiov1beta1.Isti
 	}
 	config.Spec.SetMeshNetworks(meshNetworks)
 
-	reconcilers := []resources.ComponentReconciler{
-		base.New(r.Client, config, false, r.operatorConfig, r.mgr.GetScheme()),
-		webhookcert.New(r.Client, config, r.operatorConfig, r.mgr.GetScheme()),
-		citadel.New(citadel.Configuration{
-			DeployMeshWidePolicy: true,
-		}, r.Client, r.dynamic, config, r.mgr.GetScheme()),
-		galley.New(r.Client, config, r.mgr.GetScheme()),
-		sidecarinjector.New(r.Client, config, r.mgr.GetScheme()),
-		pilot.New(r.Client, r.dynamic, config, r.mgr.GetScheme()),
-		istiod.New(r.Client, r.dynamic, config, r.operatorConfig, r.mgr.GetScheme()),
-		cni.New(r.Client, config, r.mgr.GetScheme()),
-		nodeagent.New(r.Client, config, r.mgr.GetScheme()),
-		istiocoredns.New(r.Client, config, r.mgr.GetScheme()),
-		mixerlesstelemetry.New(r.Client, r.dynamic, config, r.mgr.GetScheme()),
-		ingressgateway.New(r.Client, r.dynamic, config, false, r.mgr.GetScheme()),
-		egressgateway.New(r.Client, r.dynamic, config, false, r.mgr.GetScheme()),
-		meshexpansion.New(r.Client, r.dynamic, config, false, r.mgr.GetScheme()),
-	}
+	reconcilers := r.getReconcilers(config)
 
 	for _, rec := range reconcilers {
 		err = rec.Reconcile(logger)
@@ -398,6 +389,27 @@ func (r *ReconcileIstio) reconcile(logger logr.Logger, config *istiov1beta1.Isti
 	}
 
 	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileIstio) getReconcilers(config *istiov1beta1.Istio) []resources.ComponentReconciler {
+	return []resources.ComponentReconciler{
+		base.New(r.Client, config, false, r.operatorConfig, r.mgr.GetScheme()),
+		webhookcert.New(r.Client, config, r.operatorConfig, r.mgr.GetScheme()),
+		citadel.New(citadel.Configuration{
+			DeployMeshWidePolicy: true,
+		}, r.Client, r.dynamic, config, r.mgr.GetScheme()),
+		galley.New(r.Client, config, r.mgr.GetScheme()),
+		sidecarinjector.New(r.Client, config, r.mgr.GetScheme()),
+		pilot.New(r.Client, r.dynamic, config, r.mgr.GetScheme()),
+		istiod.New(r.Client, r.dynamic, config, r.operatorConfig, r.mgr.GetScheme()),
+		cni.New(r.Client, config, r.mgr.GetScheme()),
+		nodeagent.New(r.Client, config, r.mgr.GetScheme()),
+		istiocoredns.New(r.Client, config, r.mgr.GetScheme()),
+		mixerlesstelemetry.New(r.Client, r.dynamic, config, r.mgr.GetScheme()),
+		ingressgateway.New(r.Client, r.dynamic, config, false, r.mgr.GetScheme()),
+		egressgateway.New(r.Client, r.dynamic, config, false, r.mgr.GetScheme()),
+		meshexpansion.New(r.Client, r.dynamic, config, false, r.mgr.GetScheme()),
+	}
 }
 
 func (r *ReconcileIstio) validateLegacyIstioComponentsAreDisabled(config *istiov1beta1.Istio) error {

--- a/pkg/remoteclusters/cluster.go
+++ b/pkg/remoteclusters/cluster.go
@@ -254,6 +254,22 @@ func (c *Cluster) initK8SClients() error {
 	return nil
 }
 
+func (c *Cluster) Cleanup() error {
+	var ReconcilerFuncs []func(remoteConfig *istiov1beta1.RemoteIstio, istio *istiov1beta1.Istio) error
+
+	ReconcilerFuncs = append(ReconcilerFuncs,
+		c.CleanupComponents,
+	)
+
+	for _, f := range ReconcilerFuncs {
+		if err := f(c.remoteConfig, c.istioConfig); err != nil {
+			return emperror.Wrapf(err, "could not reconcile")
+		}
+	}
+
+	return nil
+}
+
 func (c *Cluster) Reconcile(remoteConfig *istiov1beta1.RemoteIstio, istio *istiov1beta1.Istio) error {
 	c.log.Info("reconciling remote istio")
 
@@ -293,7 +309,7 @@ func (c *Cluster) Reconcile(remoteConfig *istiov1beta1.RemoteIstio, istio *istio
 		c.reconcileEnabledServices,
 		c.ReconcileEnabledServiceEndpoints,
 		c.reconcileNamespaceInjectionLabels,
-		c.reconcileComponents,
+		c.ReconcileComponents,
 	)
 
 	for _, f := range ReconcilerFuncs {
@@ -341,6 +357,8 @@ func (c *Cluster) RemoveRemoteIstioComponents() error {
 	if err != nil && k8serrors.IsNotFound(err) {
 		return emperror.Wrap(err, "could not remove mesh gateway CRD from remote cluster")
 	}
+
+	c.Cleanup()
 
 	return nil
 }

--- a/pkg/resources/base/base.go
+++ b/pkg/resources/base/base.go
@@ -59,6 +59,10 @@ func New(client client.Client, config *istiov1beta1.Istio, isRemote bool, operat
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/citadel/citadel.go
+++ b/pkg/resources/citadel/citadel.go
@@ -70,6 +70,10 @@ func GetDeploymentName() string {
 	return deploymentName
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/cni/cni.go
+++ b/pkg/resources/cni/cni.go
@@ -68,6 +68,10 @@ func New(client client.Client, config *istiov1beta1.Istio, scheme *runtime.Schem
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/egressgateway/egressgateway.go
+++ b/pkg/resources/egressgateway/egressgateway.go
@@ -58,6 +58,10 @@ func New(client client.Client, dc dynamic.Interface, config *istiov1beta1.Istio,
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/galley/galley.go
+++ b/pkg/resources/galley/galley.go
@@ -63,6 +63,10 @@ func New(client client.Client, config *istiov1beta1.Istio, scheme *runtime.Schem
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/ingressgateway/ingressgateway.go
+++ b/pkg/resources/ingressgateway/ingressgateway.go
@@ -60,6 +60,10 @@ func New(client client.Client, dc dynamic.Interface, config *istiov1beta1.Istio,
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/istiocoredns/istiocoredns.go
+++ b/pkg/resources/istiocoredns/istiocoredns.go
@@ -63,6 +63,10 @@ func New(client client.Client, config *istiov1beta1.Istio, scheme *runtime.Schem
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/istiod/istiod.go
+++ b/pkg/resources/istiod/istiod.go
@@ -76,6 +76,25 @@ func New(client client.Client, dc dynamic.Interface, config *istiov1beta1.Istio,
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	log = log.WithValues("component", componentName)
+
+	log.Info("cleanup")
+
+	for _, res := range []resources.ResourceWithDesiredState{
+		{Resource: r.clusterRole, DesiredState: k8sutil.DesiredStateAbsent},
+		{Resource: r.clusterRoleBinding, DesiredState: k8sutil.DesiredStateAbsent},
+		{Resource: r.validatingWebhook, DesiredState: k8sutil.DesiredStateAbsent},
+	} {
+		o := res.Resource()
+		err := k8sutil.Reconcile(log, r.Client, o, res.DesiredState)
+		if err != nil {
+			return emperror.WrapWith(err, "failed to reconcile resource", "resource", o.GetObjectKind().GroupVersionKind())
+		}
+	}
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/meshexpansion/gateway.go
+++ b/pkg/resources/meshexpansion/gateway.go
@@ -64,6 +64,10 @@ func New(client client.Client, dc dynamic.Interface, config *istiov1beta1.Istio,
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/mixerlesstelemetry/mixerlesstelemetry.go
+++ b/pkg/resources/mixerlesstelemetry/mixerlesstelemetry.go
@@ -54,6 +54,10 @@ func New(client client.Client, dc dynamic.Interface, config *istiov1beta1.Istio,
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/nodeagent/nodeagent.go
+++ b/pkg/resources/nodeagent/nodeagent.go
@@ -59,6 +59,10 @@ func New(client client.Client, config *istiov1beta1.Istio, scheme *runtime.Schem
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/pilot/pilot.go
+++ b/pkg/resources/pilot/pilot.go
@@ -64,6 +64,10 @@ func New(client client.Client, dc dynamic.Interface, config *istiov1beta1.Istio,
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -33,6 +33,7 @@ type Reconciler struct {
 
 type ComponentReconciler interface {
 	Reconcile(log logr.Logger) error
+	Cleanup(log logr.Logger) error
 }
 
 type Resource func() runtime.Object

--- a/pkg/resources/webhookcert/webhookcert.go
+++ b/pkg/resources/webhookcert/webhookcert.go
@@ -51,6 +51,10 @@ func New(client client.Client, config *istiov1beta1.Istio, operatorConfig config
 	}
 }
 
+func (r *Reconciler) Cleanup(log logr.Logger) error {
+	return nil
+}
+
 func (r *Reconciler) Reconcile(log logr.Logger) error {
 	log = log.WithValues("component", componentName)
 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Adds components cleanup on CR removal.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

From 1.20+ k8s the GC is (rightfully) not removing cluster wide object that has namespaced resource owner when that owner is removed, thus those resources must be removed by other means.
