### PR TITLE
[1.10] Automate API and static tag push on make release command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,11 @@ include test/e2e/e2e-test.mk
 TEST_RACE_DETECTOR ?= 0
 
 RELEASE_TYPE ?= p
-RELEASE_MSG ?= "operator release"
+RELEASE_MSG ?= "istio operator release"
+API_RELEASE_MSG ?= "istio operator api release"
 
 REL_TAG = $(shell ./scripts/increment_version.sh -${RELEASE_TYPE} ${TAG})
+API_REL_TAG ?= pkg/apis/${REL_TAG}
 
 GOLANGCI_VERSION = 1.31.0
 LICENSEI_VERSION = 0.1.0
@@ -148,7 +150,7 @@ docker-push:
 	docker push ${IMG}
 
 check_release:
-	@echo "A new tag (${REL_TAG}) will be pushed to Github, and a new Docker image will be released. Are you sure? [y/N] " && read -r ans && [ "$${ans:-N}" = y ]
+	@echo "New tags (${REL_TAG} and ${API_REL_TAG}) will be pushed to Github, and a new Docker image (${REL_TAG}) will be released. Are you sure? [y/N] " && read -r ans && [ "$${ans:-N}" = y ]
 
 .PHONY: check-diff
 check-diff:
@@ -156,7 +158,8 @@ check-diff:
 
 release: check_release
 	git tag -a ${REL_TAG} -m ${RELEASE_MSG}
-	git push origin ${REL_TAG}
+	git tag -a ${API_REL_TAG} -m ${API_RELEASE_MSG}
+	git push origin ${REL_TAG} ${API_REL_TAG}
 
 .PHONY: shellcheck-makefile
 shellcheck-makefile: bin/shellcheck ## Check each makefile recipe using shellcheck

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ TEST_RACE_DETECTOR ?= 0
 RELEASE_TYPE ?= p
 RELEASE_MSG ?= "istio operator release"
 API_RELEASE_MSG ?= "istio operator api release"
+STATIC_RELEASE_MSG ?= "istio operator static charts release"
 
 REL_TAG = $(shell ./scripts/increment_version.sh -${RELEASE_TYPE} ${TAG})
 API_REL_TAG ?= pkg/apis/${REL_TAG}
+STATIC_REL_TAG ?= static/${REL_TAG}
 
 GOLANGCI_VERSION = 1.31.0
 LICENSEI_VERSION = 0.1.0
@@ -150,7 +152,7 @@ docker-push:
 	docker push ${IMG}
 
 check_release:
-	@echo "New tags (${REL_TAG} and ${API_REL_TAG}) will be pushed to Github, and a new Docker image (${REL_TAG}) will be released. Are you sure? [y/N] " && read -r ans && [ "$${ans:-N}" = y ]
+	@echo "New tags (${REL_TAG}, ${API_REL_TAG} and ${STATIC_REL_TAG}) will be pushed to Github, and a new Docker image (${REL_TAG}) will be released. Are you sure? [y/N] " && read -r ans && [ "$${ans:-N}" = y ]
 
 .PHONY: check-diff
 check-diff:
@@ -159,7 +161,8 @@ check-diff:
 release: check_release
 	git tag -a ${REL_TAG} -m ${RELEASE_MSG}
 	git tag -a ${API_REL_TAG} -m ${API_RELEASE_MSG}
-	git push origin ${REL_TAG} ${API_REL_TAG}
+	git tag -a ${STATIC_REL_TAG} -m ${STATIC_RELEASE_MSG}
+	git push origin ${REL_TAG} ${API_REL_TAG} ${STATIC_REL_TAG}
 
 .PHONY: shellcheck-makefile
 shellcheck-makefile: bin/shellcheck ## Check each makefile recipe using shellcheck


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

On `make release` command a new `pkg/apis/${REL_TAG}` and `static/${REL_TAG}` will be pushed as well (besides the already pushed `${REL_TAG}` tag).

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To make API and static tag pushes easier and even more importantly so that these tags are not forgotten to be pushed.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

It's not always the case that the operator and API and/or static charts change at the same time, which means that we could use separate versions for them. With this PR, I propose to use consistent versioning and bump all versions even if only one of them is changed to make our life easier.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
