### PR TITLE
add bank-vaults mutation skip label

### DIFF
--- a/pkg/resources/istiod/deployment.go
+++ b/pkg/resources/istiod/deployment.go
@@ -218,6 +218,16 @@ func (r *Reconciler) initContainers() []apiv1.Container {
 	return containers
 }
 
+func (r *Reconciler) bankVaultsMutationSkipLabel() map[string]string {
+	if util.PointerToBool(r.Config.Spec.Istiod.CA.Vault.Enabled) {
+		return map[string]string{
+			"security.banzaicloud.io/mutate": "skip",
+		}
+	}
+
+	return nil
+}
+
 func (r *Reconciler) containers() []apiv1.Container {
 	discoveryContainer := apiv1.Container{
 		Name:            "discovery",
@@ -507,7 +517,7 @@ func (r *Reconciler) deployment() runtime.Object {
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      util.MergeMultipleStringMaps(istiodLabels, pilotLabelSelector, r.Config.RevisionLabels(), v1beta1.DisableInjectionLabel),
+					Labels:      util.MergeMultipleStringMaps(istiodLabels, pilotLabelSelector, r.Config.RevisionLabels(), v1beta1.DisableInjectionLabel, r.bankVaultsMutationSkipLabel()),
 					Annotations: util.MergeStringMaps(templates.DefaultDeployAnnotations(), r.Config.Spec.Pilot.PodAnnotations),
 				},
 				Spec: apiv1.PodSpec{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Banks-vault mutation webhook skipping label was added to istiod deployment in case of the vault CA cert support is turned on.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Banks-vaults webhook would mutate the deployment and mess up the directly injected init container already placed there by the istio-operator.
