### PR TITLE
[v2] Fix RBAC rules

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,9 +42,17 @@ rules:
   - ""
   resources:
   - nodes
-  - pods
   - replicationcontrollers
   verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - deletecollection
   - get
   - list
   - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -260,6 +260,7 @@ rules:
   - servicemesh.cisco.com
   resources:
   - istiocontrolplanes
+  - istiomeshes
   verbs:
   - create
   - delete
@@ -272,6 +273,7 @@ rules:
   - servicemesh.cisco.com
   resources:
   - istiocontrolplanes/status
+  - istiomeshes/status
   verbs:
   - get
   - patch

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -71,7 +71,8 @@ type IstioControlPlaneReconciler struct {
 	ctrl             controller.Controller
 }
 
-// +kubebuilder:rbac:groups="",resources=nodes;pods;replicationcontrollers,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=nodes;replicationcontrollers,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;deletecollection
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;update;patch
 // +kubebuilder:rbac:groups="",resources=configmaps;endpoints;secrets;services;serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -96,8 +96,8 @@ type IstioControlPlaneReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.istio.io;telemetry.istio.io;authentication.istio.io;config.istio.io;rbac.istio.io,resources=*,verbs=get;watch;list;update
-// +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes;istiomeshes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes/status;istiomeshes/status,verbs=get;update;patch
 
 func (r *IstioControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/deploy/charts/istio-operator/templates/operator-rbac.yaml
+++ b/deploy/charts/istio-operator/templates/operator-rbac.yaml
@@ -52,9 +52,17 @@ rules:
   - ""
   resources:
   - nodes
-  - pods
   - replicationcontrollers
   verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - deletecollection
   - get
   - list
   - watch

--- a/deploy/charts/istio-operator/templates/operator-rbac.yaml
+++ b/deploy/charts/istio-operator/templates/operator-rbac.yaml
@@ -270,6 +270,7 @@ rules:
   - servicemesh.cisco.com
   resources:
   - istiocontrolplanes
+  - istiomeshes
   verbs:
   - create
   - delete
@@ -282,6 +283,7 @@ rules:
   - servicemesh.cisco.com
   resources:
   - istiocontrolplanes/status
+  - istiomeshes/status
   verbs:
   - get
   - patch


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To avoid the following issues:

- `User "system:serviceaccount:smm-system:istio-operator-v111x" cannot list resource "istiomeshes" in API group "servicemesh.cisco.com" at the cluster scope`
- `pods is forbidden: User \"system:serviceaccount:smm-system:istio-operator-v111x\" cannot deletecollection resource \"pods\" in API group \"\" in the namespace \"istio-system\""`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Helm chart updated
