### PR TITLE
[v2] Support JWTPolicy auto detection

### DIFF
--- a/config/samples/servicemesh_v1alpha1_istiocontrolplane.yaml
+++ b/config/samples/servicemesh_v1alpha1_istiocontrolplane.yaml
@@ -72,7 +72,6 @@ spec:
   proxyWasm:
     enabled: false
   watchOneNamespace: false
-  jwtPolicy: "THIRD_PARTY_JWT"
   caAddress: ""
   distribution: "official"
   httpProxyEnvs:

--- a/controllers/defaults.go
+++ b/controllers/defaults.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 Cisco Systems, Inc. and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/rest"
+
+	"github.com/banzaicloud/istio-operator/v2/api/v1alpha1"
+	"github.com/banzaicloud/istio-operator/v2/pkg/k8sutil"
+)
+
+func setDynamicDefaults(icp *v1alpha1.IstioControlPlane, k8sConfig *rest.Config, logger logr.Logger) {
+	if icp.Spec.JwtPolicy == v1alpha1.JWTPolicyType_UNSPECIFIED {
+		// try to detect supported jwt policy
+		supportedJWTPolicy, err := k8sutil.DetectSupportedJWTPolicy(k8sConfig)
+		if err != nil {
+			logger.Error(err, "could not detect supported jwt policy")
+		} else {
+			icp.Spec.JwtPolicy = supportedJWTPolicy
+			logger.Info("supported jwt policy", "policy", icp.Spec.JwtPolicy)
+		}
+	}
+}

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -41,6 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlBuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -105,8 +106,14 @@ func (r *IstioControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	_ = context.Background()
 	logger := r.Log.WithValues("istiocontrolplane", req.NamespacedName)
 
+	// Get a config to talk to the apiserver
+	k8sConfig, err := config.GetConfig()
+	if err != nil {
+		logger.Error(err, "unable to set up kube client config")
+	}
+
 	icp := &servicemeshv1alpha1.IstioControlPlane{}
-	err := r.Get(context.TODO(), req.NamespacedName, icp)
+	err = r.Get(context.TODO(), req.NamespacedName, icp)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
@@ -165,6 +172,8 @@ func (r *IstioControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	})
 
 	componentReconcilers := []components.ComponentReconciler{}
+
+	setDynamicDefaults(icp, k8sConfig, logger)
 
 	discoveryReconciler, err := NewComponentReconciler(r, func(helmReconciler *components.HelmReconciler) components.ComponentReconciler {
 		return discovery_component.NewChartReconciler(helmReconciler, servicemeshv1alpha1.IstioControlPlaneProperties{

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -103,7 +103,6 @@ type IstioControlPlaneReconciler struct {
 // +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes/status;istiomeshes/status,verbs=get;update;patch
 
 func (r *IstioControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
 	logger := r.Log.WithValues("istiocontrolplane", req.NamespacedName)
 
 	// Get a config to talk to the apiserver
@@ -113,7 +112,7 @@ func (r *IstioControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 
 	icp := &servicemeshv1alpha1.IstioControlPlane{}
-	err = r.Get(context.TODO(), req.NamespacedName, icp)
+	err = r.Get(ctx, req.NamespacedName, icp)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.

--- a/pkg/k8sutil/jwtpolicy.go
+++ b/pkg/k8sutil/jwtpolicy.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2021 Cisco Systems, Inc. and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8sutil
+
+import (
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+
+	servicemeshv1alpha1 "github.com/banzaicloud/istio-operator/v2/api/v1alpha1"
+)
+
+func DetectSupportedJWTPolicy(k8sConfig *rest.Config) (servicemeshv1alpha1.JWTPolicyType, error) {
+	d, err := discovery.NewDiscoveryClientForConfig(k8sConfig)
+	if err != nil {
+		return servicemeshv1alpha1.JWTPolicyType_UNSPECIFIED, err
+	}
+
+	_, s, err := d.ServerGroupsAndResources()
+	if err != nil {
+		return servicemeshv1alpha1.JWTPolicyType_UNSPECIFIED, err
+	}
+
+	for _, res := range s {
+		for _, api := range res.APIResources {
+			if api.Name == "serviceaccounts/token" {
+				return servicemeshv1alpha1.JWTPolicyType_THIRD_PARTY_JWT, nil
+			}
+		}
+	}
+
+	return servicemeshv1alpha1.JWTPolicyType_FIRST_PARTY_JWT, nil
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Automatically detecting and setting JWTPolicy based on k8s cluster API resources.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

Since this can be automatically detected, the user doesn't have to deal with manually setting `spec.jwtPolicy` in the ICP CR.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

- Detection and auto setting only happens when no manual value is set at `spec.jwtPolicy` in the ICP CR by the user.
- If no value is set but detection doesn't work for some reason the static default value is set to `third-party-jwt` in the [values.yaml ](https://github.com/banzaicloud/istio-operator/blob/d8e1bf9ced57b6fdddf7477d2807551095830a18/internal/assets/manifests/istio-discovery/values.yaml#L412) file.
- This feature was already implemented in the v1 operator version in this PR: https://github.com/banzaicloud/istio-operator/pull/726

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
