### PR TITLE
[v2] reader secret reconciliation

### DIFF
--- a/api/v1alpha1/istiocontrolplane.pb.go
+++ b/api/v1alpha1/istiocontrolplane.pb.go
@@ -239,6 +239,7 @@ type IstioControlPlaneSpec struct {
 	// Mesh expansion configuration
 	MeshExpansion *MeshExpansionConfiguration `protobuf:"bytes,20,opt,name=meshExpansion,proto3" json:"meshExpansion,omitempty"`
 	// Cluster ID
+	// +default=Kubernetes
 	ClusterID string `protobuf:"bytes,21,opt,name=clusterID,proto3" json:"clusterID,omitempty"`
 	// Network defines the network this cluster belongs to. This name
 	// corresponds to the networks in the map of mesh networks.

--- a/api/v1alpha1/istiocontrolplane.pb.html
+++ b/api/v1alpha1/istiocontrolplane.pb.html
@@ -258,7 +258,8 @@ No
 <td><code>clusterID</code></td>
 <td><code>string</code></td>
 <td>
-<p>Cluster ID</p>
+<p>Cluster ID
++default=Kubernetes</p>
 
 </td>
 <td>

--- a/api/v1alpha1/istiocontrolplane.proto
+++ b/api/v1alpha1/istiocontrolplane.proto
@@ -114,6 +114,7 @@ message IstioControlPlaneSpec {
     // Mesh expansion configuration
     MeshExpansionConfiguration meshExpansion = 20;
     // Cluster ID
+    // +default=Kubernetes
     string clusterID = 21;
     // Network defines the network this cluster belongs to. This name
     // corresponds to the networks in the map of mesh networks.

--- a/config/crd/bases/istio-operator-crds.gen.yaml
+++ b/config/crd/bases/istio-operator-crds.gen.yaml
@@ -59,6 +59,7 @@ spec:
               caAddress:
                 type: string
               clusterID:
+                default: Kubernetes
                 type: string
               containerImageConfiguration:
                 properties:
@@ -7373,6 +7374,7 @@ spec:
               caAddress:
                 type: string
               clusterID:
+                default: Kubernetes
                 type: string
               containerImageConfiguration:
                 properties:

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -69,7 +69,8 @@ const (
 	istioControlPlaneFinalizerID               = "istio-controlplane.servicemesh.cisco.com"
 	meshExpansionGatewayRemovalRequeueDuration = time.Second * 30
 	readerServiceAccountName                   = "istio-reader"
-	readerSecretType                           = "k8s.cisco.com/istio-reader-secret"
+	// nolint:gosec
+	readerSecretType = "k8s.cisco.com/istio-reader-secret"
 )
 
 // IstioControlPlaneReconciler reconciles a IstioControlPlane object

--- a/deploy/charts/istio-operator/templates/crds/istio-operator-crds.gen.yaml
+++ b/deploy/charts/istio-operator/templates/crds/istio-operator-crds.gen.yaml
@@ -59,6 +59,7 @@ spec:
               caAddress:
                 type: string
               clusterID:
+                default: Kubernetes
                 type: string
               containerImageConfiguration:
                 properties:
@@ -7373,6 +7374,7 @@ spec:
               caAddress:
                 type: string
               clusterID:
+                default: Kubernetes
                 type: string
               containerImageConfiguration:
                 properties:

--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -133,6 +133,10 @@ func (rec *Base) IsOptional() bool {
 }
 
 func (rec *Base) UpdateStatus(object runtime.Object, status types.ReconcileStatus, message string) error {
+	if obj, ok := object.(client.Object); ok && !obj.GetDeletionTimestamp().IsZero() {
+		return nil
+	}
+
 	if c, ok := rec.Component.(interface {
 		UpdateStatus(object runtime.Object, status types.ReconcileStatus, message string) error
 	}); ok {

--- a/pkg/util/cluster_secret.go
+++ b/pkg/util/cluster_secret.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2021 Cisco Systems, Inc. and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"net/url"
+
+	"emperror.dev/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	k8sclientapiv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+func GetExternalAddressOfAPIServer(kubeConfig *rest.Config) (string, error) {
+	d, err := discovery.NewDiscoveryClientForConfig(kubeConfig)
+	if err != nil {
+		return "", errors.WithStackIf(err)
+	}
+
+	v := &metav1.APIVersions{}
+	err = d.RESTClient().Get().AbsPath(d.LegacyPrefix).Do(context.TODO()).Into(v)
+	if err != nil {
+		return "", errors.WithStackIf(err)
+	}
+
+	for _, addr := range v.ServerAddressByClientCIDRs {
+		if addr.ClientCIDR == (&net.IPNet{
+			IP:   net.IPv4zero,
+			Mask: net.IPv4Mask(0, 0, 0, 0),
+		}).String() {
+			return (&url.URL{
+				Scheme: "https",
+				Host:   addr.ServerAddress,
+			}).String(), nil
+		}
+	}
+
+	return "", errors.New("could not determine external apiserver address")
+}
+
+func GetReaderSecretForCluster(ctx context.Context, kubeClient client.Client, kubeConfig *rest.Config, clusterName string, secretRef types.NamespacedName, saRef types.NamespacedName) (*corev1.Secret, error) {
+	sa := &corev1.ServiceAccount{}
+	err := kubeClient.Get(ctx, saRef, sa)
+	if err != nil {
+		return nil, errors.WithStackIf(err)
+	}
+
+	if len(sa.Secrets) == 0 {
+		return nil, errors.NewWithDetails("could not find secret reference for sa", "sa", saRef)
+	}
+
+	secret := &corev1.Secret{}
+	err = kubeClient.Get(ctx, types.NamespacedName{
+		Name:      sa.Secrets[0].Name,
+		Namespace: sa.GetNamespace(),
+	}, secret)
+	if err != nil {
+		return nil, errors.WithStackIf(err)
+	}
+
+	caData := secret.Data["ca.crt"]
+	if !bytes.Contains(caData, kubeConfig.CAData) {
+		caData = append(append(caData, []byte("\n")...), kubeConfig.CAData...)
+	}
+
+	// try to get external ip address from api server
+	apiServerAddress, _ := GetExternalAddressOfAPIServer(kubeConfig)
+
+	if apiServerAddress == "" {
+		apiServerAddress = kubeConfig.Host
+	}
+
+	kubeconfig, err := GetKubeconfigWithSAToken(secretRef.Name, sa.GetName(), apiServerAddress, caData, string(secret.Data["token"]))
+	if err != nil {
+		return nil, errors.WithStackIf(err)
+	}
+
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretRef.Name,
+			Namespace: secretRef.Namespace,
+		},
+		Data: map[string][]byte{
+			clusterName: []byte(kubeconfig),
+		},
+	}, nil
+}
+
+func GetKubeconfigWithSAToken(name, username, url string, caData []byte, saToken string) (string, error) {
+	config := k8sclientapiv1.Config{
+		APIVersion: k8sclientapiv1.SchemeGroupVersion.Version,
+		Kind:       "Config",
+		Clusters: []k8sclientapiv1.NamedCluster{
+			{
+				Name: name,
+				Cluster: k8sclientapiv1.Cluster{
+					CertificateAuthorityData: caData,
+					Server:                   url,
+				},
+			},
+		},
+		Contexts: []k8sclientapiv1.NamedContext{
+			{
+				Name: name,
+				Context: k8sclientapiv1.Context{
+					Cluster:  name,
+					AuthInfo: username,
+				},
+			},
+		},
+		CurrentContext: name,
+		AuthInfos: []k8sclientapiv1.NamedAuthInfo{
+			{
+				Name: username,
+				AuthInfo: k8sclientapiv1.AuthInfo{
+					Token: saToken,
+				},
+			},
+		},
+	}
+
+	y, err := yaml.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+
+	return string(y), nil
+}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

The operator will manage a secret on the passive clusters that contains a kubeconfig for the reader service account.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

These secrets are used on active clusters for service discovery from the passive ones.
