### PR TITLE
[v2] Fix sidecar-injector jwtPolicy setting

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,4 +22,4 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"
+        - "--leader-election-enabled"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -26,7 +26,7 @@ spec:
       - command:
         - /manager
         args:
-        - --enable-leader-election
+        - --leader-election-enabled
         image: controller:latest
         name: manager
         resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,10 +30,7 @@ spec:
         image: controller:latest
         name: manager
         resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
-      terminationGracePeriodSeconds: 10
+            cpu: 200m
+            memory: 256Mi
+      terminationGracePeriodSeconds: 60

--- a/config/samples/servicemesh_v1alpha1_istiocontrolplane.yaml
+++ b/config/samples/servicemesh_v1alpha1_istiocontrolplane.yaml
@@ -1,7 +1,7 @@
 apiVersion: servicemesh.cisco.com/v1alpha1
 kind: IstioControlPlane
 metadata:
-  name: icp-v11x-sample
+  name: icp-v111x-sample
 spec:
   version: 1.11.0
   mode: ACTIVE
@@ -9,6 +9,8 @@ spec:
   logging:
     level: "default:info"
   mountMtlsCerts: false
+  meshExpansion:
+    enabled: false
   istiod:
     deployment:
       replicas:
@@ -100,7 +102,6 @@ spec:
       serviceCluster: istio-proxy
       drainDuration: 45s
       parentShutdownDuration: 60s
-      discoveryAddress: istiod-icp-v11x-sample.istio-system.svc:15012
       proxyAdminPort: 15000
       controlPlaneAuthPolicy: MUTUAL_TLS
       concurrency: 2

--- a/config/samples/servicemesh_v1alpha1_istiomeshgateway.yaml
+++ b/config/samples/servicemesh_v1alpha1_istiomeshgateway.yaml
@@ -27,7 +27,7 @@ spec:
       runAsNonRoot: false
       runAsUser: 0
   istioControlPlane:
-    name: icp-v11x-sample
+    name: icp-v111x-sample
     namespace: istio-system
   runAsRoot: true
   service:

--- a/internal/assets/manifests/istio-sidecar-injector/values.yaml.tpl
+++ b/internal/assets/manifests/istio-sidecar-injector/values.yaml.tpl
@@ -6,6 +6,9 @@
 {{ valueIf (dict "key" "tag" "value" .GetSpec.GetContainerImageConfiguration.GetTag) }}
 {{ valueIf (dict "key" "imagePullPolicy" "value" (default .GetSpec.GetContainerImageConfiguration.GetImagePullPolicy .GetSpec.GetSidecarInjector.GetDeployment.GetImagePullPolicy)) }}
 {{ toYamlIf (dict "key" "imagePullSecrets" "value" (default .GetSpec.GetContainerImageConfiguration.GetImagePullSecrets .GetSpec.GetSidecarInjector.GetDeployment.GetImagePullSecrets)) }}
+{{- if .GetSpec.GetJwtPolicy }}
+jwtPolicy: {{ .GetSpec.GetJwtPolicy | toString | lower | replace "_" "-" }}
+{{- end }}
 {{ end }}
 
 {{- $x := (include "global" .) | reformatYaml }}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Set `jwtPolicy` for sidecar-injector helm chart and few other small fixes.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

`jwtPolicy` was not set hence always the default value (`third-party-jwt`) was used.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
