### PR TITLE
[v2] Add flat network support

### DIFF
--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -527,7 +527,7 @@ func (r *IstioControlPlaneReconciler) reconcileIstiodEndpoint(ctx context.Contex
 	serviceName := icp.WithRevision("istiod")
 	serviceNamespace := icp.GetNamespace()
 
-	istiodEndpointAddresses, err := pkgUtil.GetIstiodEndpointAddresses(ctx, r.Client, icp.GetName(), serviceNamespace)
+	istiodEndpointAddresses, err := pkgUtil.GetIstiodEndpointAddresses(ctx, r.Client, icp.GetName(), icp.GetSpec().GetNetworkName(), serviceNamespace)
 	if err != nil {
 		return errors.WithStackIf(err)
 	}
@@ -616,6 +616,13 @@ func (r *IstioControlPlaneReconciler) waitForMeshExpansionGatewayRemoval(ctx con
 }
 
 func (r *IstioControlPlaneReconciler) setIstiodAddressesToStatus(ctx context.Context, icp *servicemeshv1alpha1.IstioControlPlane) error {
+	if icp.GetSpec().GetMode() != servicemeshv1alpha1.ModeType_ACTIVE {
+		// istiod pods should only be present on ACTIVE clusters so it only make sense set pod IPs on those clusters
+		icp.Status.IstiodAddresses = nil
+
+		return nil
+	}
+
 	pods, err := k8sutil.GetPodsForService(ctx, r.Client, icp.WithRevision("istiod"), icp.GetNamespace())
 	if err != nil {
 		return errors.WithStackIf(err)

--- a/pkg/util/istiod_endpoints.go
+++ b/pkg/util/istiod_endpoints.go
@@ -38,19 +38,21 @@ func GetIstiodEndpointAddresses(ctx context.Context, kubeClient client.Client, i
 
 	for _, picp := range picpList.Items {
 		if picp.Status.IstioControlPlaneName == icpName {
-			if picp.Spec.GetNetworkName() == icpNetworkName {
-				for _, address := range picp.Status.IstiodAddresses {
-					istiodEndpointAddresses = append(istiodEndpointAddresses,
-						corev1.EndpointAddress{
-							IP: address,
-						})
-				}
-			} else {
-				for _, address := range picp.Status.GatewayAddress {
-					istiodEndpointAddresses = append(istiodEndpointAddresses,
-						corev1.EndpointAddress{
-							IP: address,
-						})
+			if picp.Spec.GetMode() == servicemeshv1alpha1.ModeType_ACTIVE {
+				if picp.Spec.GetNetworkName() == icpNetworkName {
+					for _, address := range picp.Status.IstiodAddresses {
+						istiodEndpointAddresses = append(istiodEndpointAddresses,
+							corev1.EndpointAddress{
+								IP: address,
+							})
+					}
+				} else {
+					for _, address := range picp.Status.GatewayAddress {
+						istiodEndpointAddresses = append(istiodEndpointAddresses,
+							corev1.EndpointAddress{
+								IP: address,
+							})
+					}
 				}
 			}
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

If the ACTIVE control plane is in the same network as the PASSIVE one, then use the istiod pod IP addresses for the `Endpoints` resource instead of the meshexpansion gateway IP addresses.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It spares a hop every time when talking to the istiod pods.

### Another smaller addition:
Only set `istiodAddresses` in ICP status on ACTIVE clusters, nil out on PASSIVE ones.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
