### PR TITLE
[v2] Only collect remote istiod addresses for ACTIVE control planes

### DIFF
--- a/pkg/util/istiod_endpoints.go
+++ b/pkg/util/istiod_endpoints.go
@@ -38,19 +38,21 @@ func GetIstiodEndpointAddresses(ctx context.Context, kubeClient client.Client, i
 
 	for _, picp := range picpList.Items {
 		if picp.Status.IstioControlPlaneName == icpName {
-			if picp.Spec.GetNetworkName() == icpNetworkName {
-				for _, address := range picp.Status.IstiodAddresses {
-					istiodEndpointAddresses = append(istiodEndpointAddresses,
-						corev1.EndpointAddress{
-							IP: address,
-						})
-				}
-			} else {
-				for _, address := range picp.Status.GatewayAddress {
-					istiodEndpointAddresses = append(istiodEndpointAddresses,
-						corev1.EndpointAddress{
-							IP: address,
-						})
+			if picp.Spec.GetMode() == servicemeshv1alpha1.ModeType_ACTIVE {
+				if picp.Spec.GetNetworkName() == icpNetworkName {
+					for _, address := range picp.Status.IstiodAddresses {
+						istiodEndpointAddresses = append(istiodEndpointAddresses,
+							corev1.EndpointAddress{
+								IP: address,
+							})
+					}
+				} else {
+					for _, address := range picp.Status.GatewayAddress {
+						istiodEndpointAddresses = append(istiodEndpointAddresses,
+							corev1.EndpointAddress{
+								IP: address,
+							})
+					}
 				}
 			}
 		}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Make sure that in the istiod `Endpoints` resource only the addresses of ACTIVE control planes are collected.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It does not make sense to add addresses for other PASSIVE clusters because there are no istiod pods on them.
