### PR TITLE
[v2] Add ResourceSyncRule resources reconciliation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -167,6 +167,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - clusterregistry.k8s.cisco.com
+  resources:
+  - resourcesyncrules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -288,6 +288,7 @@ rules:
   resources:
   - istiocontrolplanes
   - istiomeshes
+  - peeristiocontrolplanes
   verbs:
   - create
   - delete
@@ -301,6 +302,7 @@ rules:
   resources:
   - istiocontrolplanes/status
   - istiomeshes/status
+  - peeristiocontrolplanes/status
   verbs:
   - get
   - patch
@@ -325,10 +327,3 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - servicemesh.cisco.com
-  resources:
-  - peeristiocontrolplanes
-  verbs:
-  - list
-  - watch

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -61,6 +61,7 @@ import (
 	"github.com/banzaicloud/istio-operator/v2/internal/components/cni"
 	discovery_component "github.com/banzaicloud/istio-operator/v2/internal/components/discovery"
 	"github.com/banzaicloud/istio-operator/v2/internal/components/meshexpansion"
+	"github.com/banzaicloud/istio-operator/v2/internal/components/resourcesyncrule"
 	"github.com/banzaicloud/istio-operator/v2/internal/components/sidecarinjector"
 	"github.com/banzaicloud/istio-operator/v2/internal/models"
 	"github.com/banzaicloud/istio-operator/v2/internal/util"
@@ -266,6 +267,14 @@ func (r *IstioControlPlaneReconciler) reconcile(ctx context.Context, icp *servic
 		return ctrl.Result{}, err
 	}
 	componentReconcilers = append(componentReconcilers, sidecarInjectorReconciler)
+
+	resourceSyncRuleReconciler, err := NewComponentReconciler(r, func(helmReconciler *components.HelmReconciler) components.ComponentReconciler {
+		return resourcesyncrule.NewChartReconciler(helmReconciler, r.ClusterRegistry.ResourceSyncRules.Enabled)
+	}, r.Log.WithName("resourcesyncrule"))
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	componentReconcilers = append(componentReconcilers, resourceSyncRuleReconciler)
 
 	var result ctrl.Result
 	for _, r := range componentReconcilers {

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -120,9 +120,8 @@ type IstioControlPlaneReconciler struct {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=*,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.istio.io;telemetry.istio.io;authentication.istio.io;config.istio.io;rbac.istio.io,resources=*,verbs=get;watch;list;update
-// +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes;istiomeshes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes/status;istiomeshes/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=peeristiocontrolplanes,verbs=list;watch
+// +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes;peeristiocontrolplanes;istiomeshes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes/status;peeristiocontrolplanes/status;istiomeshes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=clusterregistry.k8s.cisco.com,resources=clusters,verbs=list;watch
 // +kubebuilder:rbac:groups=clusterregistry.k8s.cisco.com,resources=resourcesyncrules,verbs=get;list;watch;create;update;patch;delete
 

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -124,6 +124,7 @@ type IstioControlPlaneReconciler struct {
 // +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes/status;istiomeshes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=peeristiocontrolplanes,verbs=list;watch
 // +kubebuilder:rbac:groups=clusterregistry.k8s.cisco.com,resources=clusters,verbs=list;watch
+// +kubebuilder:rbac:groups=clusterregistry.k8s.cisco.com,resources=resourcesyncrules,verbs=get;list;watch;create;update;patch;delete
 
 func (r *IstioControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("istiocontrolplane", req.NamespacedName)

--- a/deploy/charts/istio-operator/README.md
+++ b/deploy/charts/istio-operator/README.md
@@ -57,5 +57,6 @@ Parameter | Description | Default
 `leaderElection.enabled` | If true, leader election is enabled for the operator deployment | `false`
 `leaderElection.namespace` | Namespace for the leader election configmap | `istio-system`
 `leaderElection.nameOverride` | Name override for the leader election configmap | `""`
-`clusterRegistry.clusterAPI.enabled` | If true, [cluster registry](https://github.com/banzaicloud/cluster-registry) API is used from the cluster | `false`
 `apiServerEndpointAddress` | Endpoint address of the API server of the cluster the controller is running on | `""`
+`clusterRegistry.clusterAPI.enabled` | If true, [cluster registry](https://github.com/banzaicloud/cluster-registry) API is used from the cluster | `false`
+`clusterRegistry.resourceSyncRules.enabled` | If true, the necessary ResourceSyncRule resources from the [cluster registry](https://github.com/banzaicloud/cluster-registry) API are automatically created for multi cluster setups | `false`

--- a/deploy/charts/istio-operator/templates/operator-deployment.yaml
+++ b/deploy/charts/istio-operator/templates/operator-deployment.yaml
@@ -61,10 +61,13 @@ spec:
           {{- end }}
           - "--leader-election-namespace={{ .Values.leaderElection.namespace }}"
           {{- end }}
+          - "--apiserver-endpoint-address={{ .Values.apiServerEndpointAddress }}"
           {{- if .Values.clusterRegistry.clusterAPI.enabled }}
           - "--cluster-registry-api-enabled"
           {{- end }}
-          - "--apiserver-endpoint-address={{ .Values.apiServerEndpointAddress }}"
+          {{- if .Values.clusterRegistry.resourceSyncRules.enabled }}
+          - "--cluster-registry-sync-rules-enabled"
+          {{- end }}
           {{- range $value := .Values.extraArgs }}
           - {{ quote $value }}
           {{- end }}

--- a/deploy/charts/istio-operator/templates/operator-rbac.yaml
+++ b/deploy/charts/istio-operator/templates/operator-rbac.yaml
@@ -177,6 +177,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - clusterregistry.k8s.cisco.com
+  resources:
+  - resourcesyncrules
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/deploy/charts/istio-operator/templates/operator-rbac.yaml
+++ b/deploy/charts/istio-operator/templates/operator-rbac.yaml
@@ -298,6 +298,7 @@ rules:
   resources:
   - istiocontrolplanes
   - istiomeshes
+  - peeristiocontrolplanes
   verbs:
   - create
   - delete
@@ -311,6 +312,7 @@ rules:
   resources:
   - istiocontrolplanes/status
   - istiomeshes/status
+  - peeristiocontrolplanes/status
   verbs:
   - get
   - patch
@@ -335,13 +337,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - servicemesh.cisco.com
-  resources:
-  - peeristiocontrolplanes
-  verbs:
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/charts/istio-operator/values.yaml
+++ b/deploy/charts/istio-operator/values.yaml
@@ -56,3 +56,5 @@ apiServerEndpointAddress: ""
 clusterRegistry:
   clusterAPI:
     enabled: false
+  resourceSyncRules:
+    enabled: false

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	emperror.dev/errors v0.8.0
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
-	github.com/banzaicloud/cluster-registry v0.0.4
+	github.com/banzaicloud/cluster-registry v0.0.5
 	github.com/banzaicloud/istio-operator/v2/api v0.0.1
 	github.com/banzaicloud/k8s-objectmatcher v1.5.2
 	github.com/banzaicloud/operator-tools v0.24.1-0.20210917222015-90c6c0b3cffe

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/banzaicloud/cluster-registry v0.0.4 h1:xhQmmUxraGrlVv/WpRDDzEnVJv345TqGNmuRrTUqPik=
-github.com/banzaicloud/cluster-registry v0.0.4/go.mod h1:2tcT4bq6UaWOOeIBsjcrqawOfrybamYUJSM4jRVHQic=
+github.com/banzaicloud/cluster-registry v0.0.5 h1:mUfDexjyAtrZ6Ylqp0/55u2G4ie0Ea5iYUDTdeh39yw=
+github.com/banzaicloud/cluster-registry v0.0.5/go.mod h1:2tcT4bq6UaWOOeIBsjcrqawOfrybamYUJSM4jRVHQic=
 github.com/banzaicloud/k8s-objectmatcher v1.5.0/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
 github.com/banzaicloud/k8s-objectmatcher v1.5.1/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
 github.com/banzaicloud/k8s-objectmatcher v1.5.2 h1:wY3YBAVnh36Gm957IIlvtZbKVXbg4b+6fwrhoTz3opE=

--- a/internal/assets/assets.go
+++ b/internal/assets/assets.go
@@ -51,6 +51,11 @@ var (
 	//go:embed manifests/istio-sidecar-injector/templates/_helpers.tpl
 	istioSidecarInjector embed.FS
 	IstioSidecarInjector = GetSubFS(istioSidecarInjector, "manifests/istio-sidecar-injector")
+
+	//go:embed manifests/resource-sync-rule
+	//go:embed manifests/resource-sync-rule/templates/_helpers.tpl
+	resourceSyncRule embed.FS
+	ResourceSyncRule = GetSubFS(resourceSyncRule, "manifests/resource-sync-rule")
 )
 
 func GetSubFS(fsys fs.FS, dir string) (subFS fs.FS) {

--- a/internal/assets/manifests/resource-sync-rule/Chart.yaml
+++ b/internal/assets/manifests/resource-sync-rule/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+name: istio-resource-sync-rule
+version: 1.1.0
+description: Helm chart for resource sync rule components for Istio
+keywords:
+  - istio
+  - resource-sync-rule
+engine: gotpl
+icon: https://istio.io/latest/favicons/android-192x192.png

--- a/internal/assets/manifests/resource-sync-rule/templates/_helpers.tpl
+++ b/internal/assets/manifests/resource-sync-rule/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "revision" -}}
+{{- default "default" (.Values.revision | replace "." "-") -}}
+{{- end -}}
+
+{{- define "namespaced-revision" -}}
+{{- $revision := (include "revision" .) -}}
+{{- if eq $revision "default" -}}
+{{- printf "%s" $revision -}}
+{{- else -}}
+{{- printf "%s.%s" $revision .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "name-with-revision" -}}
+{{- if .context.Values.revision -}}
+{{- printf "%s-%s" .name (include "revision" .context) -}}
+{{- else -}}
+{{- .name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "name-with-namespaced-revision" -}}
+{{- if .context.Values.revision -}}
+{{- printf "%s-%s" (include "name-with-revision" .) .context.Release.Namespace -}}
+{{- else -}}
+{{- .name -}}
+{{- end -}}
+{{- end -}}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-controller-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-controller-clusterrole.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.mode "PASSIVE" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "istio-ca-root-cert-controller" "context" $) }}
+  labels:
+    cluster-registry.k8s.cisco.com/controller-aggregated: "true"
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - create
+    - update
+    - delete
+    - patch
+    - get
+    - list
+    - watch
+{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-reader-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-reader-clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if eq .Values.mode "ACTIVE" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "istio-ca-root-cert-reader" "context" $) }}
+  labels:
+    cluster-registry.k8s.cisco.com/reader-aggregated: "true"
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-reader-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-reader-clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.mode "ACTIVE" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -15,4 +14,3 @@ rules:
     - get
     - list
     - watch
-{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-resource-sync-rule.yaml
@@ -13,7 +13,7 @@ spec:
     version: v1
   rules:
   - match:
-      objectKey:
+    - objectKey:
         {{- if eq .Values.distribution "cisco" }}
         name: {{ include "name-with-revision" (dict "name" "istio-ca-root-cert" "context" $) }}
         {{- else }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-resource-sync-rule.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.mode "PASSIVE" }}
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ResourceSyncRule
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "istio-ca-root-cert" "context" $) }}
+  annotations:
+    cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
+  labels:
+    release: {{ .Release.Name }}
+spec:
+  groupVersionKind:
+    kind: ConfigMap
+    version: v1
+  rules:
+  - match:
+      objectKey:
+        {{- if eq .Values.distribution "cisco" }}
+        name: {{ include "name-with-revision" (dict "name" "istio-ca-root-cert" "context" $) }}
+        {{- else }}
+        name: istio-ca-root-cert
+        {{- end }}
+{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
@@ -1,0 +1,26 @@
+{{- if eq .Values.mode "ACTIVE" }}
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ResourceSyncRule
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "istio-multi-cluster-secret" "context" $) }}
+  annotations:
+    cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
+  labels:
+    release: {{ .Release.Name }}
+spec:
+  groupVersionKind:
+    kind: Secret
+    version: v1
+  rules:
+  - match:
+      labels:
+      - matchLabels:
+          istio.io/rev: {{ include "namespaced-revision" . }}
+      content:
+      - key: type
+        value: k8s.cisco.com/istio-reader-secret
+    mutations:
+      labels:
+        add:
+          istio/multiCluster: "true"
+{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
@@ -13,7 +13,7 @@ spec:
     version: v1
   rules:
   - match:
-      labels:
+    - labels:
       - matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
       content:

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-controller-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-controller-clusterrole.yaml
@@ -10,7 +10,6 @@ rules:
   - apiGroups: ["servicemesh.cisco.com"]
     resources:
     - istiomeshes
-    - istiomeshes/status
     verbs:
     - create
     - update
@@ -19,4 +18,11 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["servicemesh.cisco.com"]
+    resources:
+    - istiomeshes/status
+    verbs:
+    - get
+    - update
+    - patch
 {{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-controller-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-controller-clusterrole.yaml
@@ -1,0 +1,22 @@
+{{- if eq .Values.mode "PASSIVE" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "mesh-controller" "context" $) }}
+  labels:
+    cluster-registry.k8s.cisco.com/controller-aggregated: "true"
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: ["servicemesh.cisco.com"]
+    resources:
+    - istiomeshes
+    - istiomeshes/status
+    verbs:
+    - create
+    - update
+    - delete
+    - patch
+    - get
+    - list
+    - watch
+{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-reader-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-reader-clusterrole.yaml
@@ -1,0 +1,17 @@
+{{- if eq .Values.mode "ACTIVE" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "mesh-reader" "context" $) }}
+  labels:
+    cluster-registry.k8s.cisco.com/reader-aggregated: "true"
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: ["servicemesh.cisco.com"]
+    resources:
+    - istiomeshes
+    verbs:
+    - get
+    - list
+    - watch
+{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-reader-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-reader-clusterrole.yaml
@@ -1,4 +1,3 @@
-{{- if eq .Values.mode "ACTIVE" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,4 +13,3 @@ rules:
     - get
     - list
     - watch
-{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
@@ -14,7 +14,7 @@ spec:
     version: v1alpha1
   rules:
   - match:
-      objectKey:
+    - objectKey:
         name: {{ .Values.meshID }}
         namespace: {{ .Release.Namespace }}
       syncStatus: true

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
@@ -1,0 +1,21 @@
+{{- if eq .Values.mode "PASSIVE" }}
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ResourceSyncRule
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "mesh" "context" $) }}
+  annotations:
+    cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
+  labels:
+    release: {{ .Release.Name }}
+spec:
+  groupVersionKind:
+    group: servicemesh.cisco.com
+    kind: IstioMesh
+    version: v1alpha1
+  rules:
+  - match:
+      objectKey:
+        name: {{ .Values.meshID }}
+        namespace: {{ .Release.Namespace }}
+      syncStatus: true
+{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-controller-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-controller-clusterrole.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "peeristiocontrolplane-controller" "context" $) }}
+  labels:
+    cluster-registry.k8s.cisco.com/controller-aggregated: "true"
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: ["servicemesh.cisco.com"]
+    resources:
+    - istiocontrolplanes
+    - peeristiocontrolplanes
+    - istiocontrolplanes/status
+    - peeristiocontrolplanes/status
+    verbs:
+    - create
+    - update
+    - delete
+    - patch
+    - get
+    - list
+    - watch

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-controller-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-controller-clusterrole.yaml
@@ -10,8 +10,6 @@ rules:
     resources:
     - istiocontrolplanes
     - peeristiocontrolplanes
-    - istiocontrolplanes/status
-    - peeristiocontrolplanes/status
     verbs:
     - create
     - update
@@ -20,3 +18,11 @@ rules:
     - get
     - list
     - watch
+  - apiGroups: ["servicemesh.cisco.com"]
+    resources:
+    - istiocontrolplanes/status
+    - peeristiocontrolplanes/status
+    verbs:
+    - get
+    - update
+    - patch

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-reader-clusterrole.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-reader-clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "peeristiocontrolplane-reader" "context" $) }}
+  labels:
+    cluster-registry.k8s.cisco.com/reader-aggregated: "true"
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: ["servicemesh.cisco.com"]
+    resources:
+    - istiocontrolplanes
+    verbs:
+    - get
+    - list
+    - watch

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
@@ -1,0 +1,28 @@
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ResourceSyncRule
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "peeristiocontrolplane" "context" $) }}
+  annotations:
+    cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
+  labels:
+    release: {{ .Release.Name }}
+spec:
+  groupVersionKind:
+    group: servicemesh.cisco.com
+    kind: IstioControlPlane
+    version: v1alpha1
+  rules:
+  - match:
+      objectKey:
+        name: {{ .Values.revision }}
+  - mutations:
+      overrides:
+        - parseValue: false
+          path: /kind
+          type: replace
+          value: PeerIstioControlPlane
+        - parseValue: false
+          path: /metadata/name
+          type: replace
+          value: '{{`printf "%s-%s" .Object.GetName .Cluster.GetName`}}'
+      syncStatus: true

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
@@ -15,6 +15,7 @@ spec:
   - match:
       objectKey:
         name: {{ .Values.revision }}
+        namespace: {{ .Release.Namespace }}
   - mutations:
       overrides:
         - parseValue: false

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
@@ -13,7 +13,7 @@ spec:
     version: v1alpha1
   rules:
   - match:
-      objectKey:
+    - objectKey:
         name: {{ .Values.revision }}
         namespace: {{ .Release.Namespace }}
   - mutations:
@@ -25,5 +25,5 @@ spec:
         - parseValue: false
           path: /metadata/name
           type: replace
-          value: '{{`printf "%s-%s" .Object.GetName .Cluster.GetName`}}'
+          value: {{`'{{ printf "%s-%s" .Object.GetName .Cluster.GetName }}'`}}
       syncStatus: true

--- a/internal/assets/manifests/resource-sync-rule/values.yaml
+++ b/internal/assets/manifests/resource-sync-rule/values.yaml
@@ -1,3 +1,4 @@
 revision: ""
 mode: ACTIVE
 distribution: official
+meshID: ""

--- a/internal/assets/manifests/resource-sync-rule/values.yaml
+++ b/internal/assets/manifests/resource-sync-rule/values.yaml
@@ -1,0 +1,3 @@
+revision: ""
+mode: ACTIVE
+distribution: official

--- a/internal/assets/manifests/resource-sync-rule/values.yaml.tpl
+++ b/internal/assets/manifests/resource-sync-rule/values.yaml.tpl
@@ -1,0 +1,5 @@
+{{ valueIf (dict "key" "revision" "value" .Name) }}
+{{- if .GetSpec.GetMode }}
+mode: {{ .GetSpec.GetMode | toString }}
+{{- end }}
+{{ valueIf (dict "key" "distribution" "value" .GetSpec.GetDistribution) }}

--- a/internal/assets/manifests/resource-sync-rule/values.yaml.tpl
+++ b/internal/assets/manifests/resource-sync-rule/values.yaml.tpl
@@ -3,3 +3,4 @@
 mode: {{ .GetSpec.GetMode | toString }}
 {{- end }}
 {{ valueIf (dict "key" "distribution" "value" .GetSpec.GetDistribution) }}
+{{ valueIf (dict "key" "meshID" "value" .GetSpec.GetMeshID) }}

--- a/internal/components/resourcesyncrule/reconcile.go
+++ b/internal/components/resourcesyncrule/reconcile.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2021 Cisco Systems, Inc. and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcesyncrule
+
+import (
+	"net/http"
+
+	"emperror.dev/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/banzaicloud/istio-operator/v2/api/v1alpha1"
+	"github.com/banzaicloud/istio-operator/v2/internal/assets"
+	"github.com/banzaicloud/istio-operator/v2/internal/components"
+	"github.com/banzaicloud/istio-operator/v2/internal/util"
+	"github.com/banzaicloud/operator-tools/pkg/helm"
+	"github.com/banzaicloud/operator-tools/pkg/helm/templatereconciler"
+)
+
+const (
+	componentName = "istio-resource-sync-rule"
+	chartName     = "istio-resource-sync-rule"
+	releaseName   = "istio-resource-sync-rule"
+
+	valuesTemplateFileName = "values.yaml.tpl"
+)
+
+var _ components.MinimalComponent = &Component{}
+
+type Component struct {
+	resourceSyncRulesEnabled bool
+}
+
+func NewChartReconciler(helmReconciler *templatereconciler.HelmReconciler, resourceSyncRulesEnabled bool) components.ComponentReconciler {
+	return &components.Base{
+		HelmReconciler: helmReconciler,
+		Component: &Component{
+			resourceSyncRulesEnabled: resourceSyncRulesEnabled,
+		},
+	}
+}
+
+func (rec *Component) Name() string {
+	return componentName
+}
+
+func (rec *Component) Enabled(object runtime.Object) bool {
+	if controlPlane, ok := object.(*v1alpha1.IstioControlPlane); ok {
+		return controlPlane.DeletionTimestamp.IsZero() && rec.resourceSyncRulesEnabled
+	}
+
+	return true
+}
+
+func (rec *Component) ReleaseData(object runtime.Object) (*templatereconciler.ReleaseData, error) {
+	icp, ok := object.(*v1alpha1.IstioControlPlane)
+	if !ok {
+		return nil, errors.WrapIff(errors.NewPlain("object cannot be converted to an IstioControlPlane"), "%+v", object)
+	}
+
+	values, err := rec.values(object)
+	if err != nil {
+		return nil, errors.WithStackIf(err)
+	}
+
+	overlays, err := util.ConvertK8sOverlays(icp.GetSpec().GetK8SResourceOverlays())
+	if err != nil {
+		return nil, errors.WrapIf(err, "could not convert k8s resource overlays")
+	}
+
+	return &templatereconciler.ReleaseData{
+		Chart:       http.FS(assets.ResourceSyncRule),
+		Values:      values,
+		Namespace:   icp.Namespace,
+		ChartName:   chartName,
+		ReleaseName: releaseName,
+		Layers:      overlays,
+	}, nil
+}
+
+func (rec *Component) values(object runtime.Object) (helm.Strimap, error) {
+	icp, ok := object.(*v1alpha1.IstioControlPlane)
+	if !ok {
+		return nil, errors.WrapIff(errors.NewPlain("object cannot be converted to an IstioControlPlane"), "%+v", object)
+	}
+
+	values, err := util.TransformStructToStriMapWithTemplate(icp, assets.ResourceSyncRule, valuesTemplateFileName)
+	if err != nil {
+		return nil, errors.WrapIff(err, "IstioControlPlane spec cannot be converted into a map[string]interface{}: %+v", icp.Spec)
+	}
+
+	return values, nil
+}

--- a/internal/components/resourcesyncrule/resourcesyncrule_test.go
+++ b/internal/components/resourcesyncrule/resourcesyncrule_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2021 Cisco Systems, Inc. and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package resourcesyncrule_test
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"testing"
+
+	"emperror.dev/errors"
+	"emperror.dev/errors/utils/keyval"
+	testlogr "github.com/go-logr/logr/testing"
+	"github.com/homeport/dyff/pkg/dyff"
+	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/yaml"
+
+	"github.com/banzaicloud/istio-operator/v2/api/v1alpha1"
+	"github.com/banzaicloud/istio-operator/v2/internal/assets"
+	"github.com/banzaicloud/istio-operator/v2/internal/components/resourcesyncrule"
+	"github.com/banzaicloud/istio-operator/v2/internal/util"
+	"github.com/banzaicloud/operator-tools/pkg/helm/templatereconciler"
+	"github.com/banzaicloud/operator-tools/pkg/reconciler"
+)
+
+//go:embed testdata/icp-active-test-cr.yaml
+var icpActiveTestCR []byte
+
+//go:embed testdata/icp-passive-test-cr.yaml
+var icpPassiveTestCR []byte
+
+//go:embed testdata/rsr-expected-active-values.yaml
+var rsrExpectedActiveValues []byte
+
+//go:embed testdata/rsr-expected-passive-values.yaml
+var rsrExpectedPassiveValues []byte
+
+//go:embed testdata/rsr-expected-active-resource-dump.yaml
+var rsrExpectedActiveResourceDump []byte
+
+//go:embed testdata/rsr-expected-passive-resource-dump.yaml
+var rsrExpectedPassiveResourceDump []byte
+
+func TestResourceSyncRuleResourceDump(t *testing.T) {
+	t.Parallel()
+
+	testResourceSyncRuleResourceDump(t, icpActiveTestCR, rsrExpectedActiveResourceDump)
+	testResourceSyncRuleResourceDump(t, icpPassiveTestCR, rsrExpectedPassiveResourceDump)
+}
+
+func testResourceSyncRuleResourceDump(t *testing.T, icpTestCR, rsrExpectedResourceDump []byte) {
+	var icp *v1alpha1.IstioControlPlane
+	if err := yaml.Unmarshal(icpTestCR, &icp); err != nil {
+		t.Fatal(err)
+	}
+
+	reconciler := resourcesyncrule.NewChartReconciler(
+		templatereconciler.NewHelmReconciler(nil, nil, testlogr.TestLogger{
+			T: t,
+		}, fake.NewSimpleClientset().Discovery(), []reconciler.NativeReconcilerOpt{
+			reconciler.NativeReconcilerSetControllerRef(),
+		}),
+		true,
+	)
+
+	dd, err := reconciler.GetManifest(icp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := util.CompareYAMLs(rsrExpectedResourceDump, dd)
+	if err != nil {
+		t.Log(string(dd))
+		t.Fatal(err)
+	}
+
+	if len(report.Diffs) > 0 {
+		if err := (&dyff.HumanReport{
+			Report:       report,
+			OmitHeader:   false,
+			NoTableStyle: true,
+		}).WriteReport(os.Stdout); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Fatal(errors.NewPlain("generated resource dump not equals with expected"))
+	}
+}
+
+func TestResourceSyncRuleValuesTemplateTransform(t *testing.T) {
+	t.Parallel()
+
+	testResourceSyncRuleValuesTemplateTransform(t, icpActiveTestCR, rsrExpectedActiveValues)
+	testResourceSyncRuleValuesTemplateTransform(t, icpPassiveTestCR, rsrExpectedPassiveValues)
+}
+
+func testResourceSyncRuleValuesTemplateTransform(t *testing.T, icpTestCR, rsrExpectedValues []byte) {
+	var icp *v1alpha1.IstioControlPlane
+	if err := yaml.Unmarshal(icpTestCR, &icp); err != nil {
+		t.Fatal(err)
+	}
+
+	values, err := util.TransformStructToStriMapWithTemplate(icp, assets.ResourceSyncRule, "values.yaml.tpl")
+	if err != nil {
+		kv := keyval.ToMap(errors.GetDetails(err))
+		if t, ok := kv["template"]; ok {
+			fmt.Printf("%s\n", t.(string))
+		}
+		t.Fatal(err)
+	}
+
+	valuesYaml, err := yaml.Marshal(values)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := util.CompareYAMLs(rsrExpectedValues, valuesYaml)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(report.Diffs) > 0 {
+		if err := (&dyff.HumanReport{
+			Report:       report,
+			OmitHeader:   false,
+			NoTableStyle: true,
+		}).WriteReport(os.Stdout); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Fatal(errors.NewPlain("generated template values not equals with expected"))
+	}
+}

--- a/internal/components/resourcesyncrule/resourcesyncrule_test.go
+++ b/internal/components/resourcesyncrule/resourcesyncrule_test.go
@@ -62,6 +62,8 @@ func TestResourceSyncRuleResourceDump(t *testing.T) {
 }
 
 func testResourceSyncRuleResourceDump(t *testing.T, icpTestCR, rsrExpectedResourceDump []byte) {
+	t.Helper()
+
 	var icp *v1alpha1.IstioControlPlane
 	if err := yaml.Unmarshal(icpTestCR, &icp); err != nil {
 		t.Fatal(err)
@@ -108,6 +110,8 @@ func TestResourceSyncRuleValuesTemplateTransform(t *testing.T) {
 }
 
 func testResourceSyncRuleValuesTemplateTransform(t *testing.T, icpTestCR, rsrExpectedValues []byte) {
+	t.Helper()
+
 	var icp *v1alpha1.IstioControlPlane
 	if err := yaml.Unmarshal(icpTestCR, &icp); err != nil {
 		t.Fatal(err)

--- a/internal/components/resourcesyncrule/testdata/icp-active-test-cr.yaml
+++ b/internal/components/resourcesyncrule/testdata/icp-active-test-cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: servicemesh.cisco.com/v1alpha1
+kind: IstioControlPlane
+metadata:
+  name: cp-v111x
+  namespace: istio-system
+spec:
+  version: "1.11.0"
+  mode: ACTIVE
+  distribution: cisco

--- a/internal/components/resourcesyncrule/testdata/icp-active-test-cr.yaml
+++ b/internal/components/resourcesyncrule/testdata/icp-active-test-cr.yaml
@@ -7,3 +7,4 @@ spec:
   version: "1.11.0"
   mode: ACTIVE
   distribution: cisco
+  meshID: mesh1

--- a/internal/components/resourcesyncrule/testdata/icp-passive-test-cr.yaml
+++ b/internal/components/resourcesyncrule/testdata/icp-passive-test-cr.yaml
@@ -7,3 +7,4 @@ spec:
   version: "1.11.0"
   mode: PASSIVE
   distribution: cisco
+  meshID: mesh1

--- a/internal/components/resourcesyncrule/testdata/icp-passive-test-cr.yaml
+++ b/internal/components/resourcesyncrule/testdata/icp-passive-test-cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: servicemesh.cisco.com/v1alpha1
+kind: IstioControlPlane
+metadata:
+  name: cp-v111x
+  namespace: istio-system
+spec:
+  version: "1.11.0"
+  mode: PASSIVE
+  distribution: cisco

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: istio-system
+spec: {}
+status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster-registry.k8s.cisco.com/reader-aggregated: "true"
+    release: istio-resource-sync-rule
+  name: istio-ca-root-cert-reader-cp-v111x
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster-registry.k8s.cisco.com/controller-aggregated: "true"
+    release: istio-resource-sync-rule
+  name: peeristiocontrolplane-controller-cp-v111x
+rules:
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiocontrolplanes
+      - peeristiocontrolplanes
+      - istiocontrolplanes/status
+      - peeristiocontrolplanes/status
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster-registry.k8s.cisco.com/reader-aggregated: "true"
+    release: istio-resource-sync-rule
+  name: peeristiocontrolplane-reader-cp-v111x
+rules:
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiocontrolplanes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ResourceSyncRule
+metadata:
+  annotations:
+    cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
+  labels:
+    release: istio-resource-sync-rule
+  name: istio-multi-cluster-secret-cp-v111x
+spec:
+  groupVersionKind:
+    kind: Secret
+    version: v1
+  rules:
+    - match:
+        content:
+          - key: type
+            value: k8s.cisco.com/istio-reader-secret
+        labels:
+          - matchLabels:
+              istio.io/rev: cp-v111x.istio-system
+      mutations:
+        labels:
+          add:
+            istio/multiCluster: "true"
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ResourceSyncRule
+metadata:
+  annotations:
+    cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
+  labels:
+    release: istio-resource-sync-rule
+  name: peeristiocontrolplane-cp-v111x
+spec:
+  groupVersionKind:
+    group: servicemesh.cisco.com
+    kind: IstioControlPlane
+    version: v1alpha1
+  rules:
+    - match:
+        objectKey:
+          name: cp-v111x
+    - mutations:
+        overrides:
+          - parseValue: false
+            path: /kind
+            type: replace
+            value: PeerIstioControlPlane
+          - parseValue: false
+            path: /metadata/name
+            type: replace
+            value: printf "%s-%s" .Object.GetName .Cluster.GetName
+        syncStatus: true

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
@@ -102,7 +102,7 @@ spec:
     version: v1
   rules:
     - match:
-        content:
+      - content:
           - key: type
             value: k8s.cisco.com/istio-reader-secret
         labels:
@@ -128,7 +128,7 @@ spec:
     version: v1alpha1
   rules:
     - match:
-        objectKey:
+      - objectKey:
           name: cp-v111x
           namespace: istio-system
     - mutations:
@@ -140,5 +140,5 @@ spec:
           - parseValue: false
             path: /metadata/name
             type: replace
-            value: printf "%s-%s" .Object.GetName .Cluster.GetName
+            value: '{{ printf "%s-%s" .Object.GetName .Cluster.GetName }}'
         syncStatus: true

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
@@ -53,8 +53,6 @@ rules:
     resources:
       - istiocontrolplanes
       - peeristiocontrolplanes
-      - istiocontrolplanes/status
-      - peeristiocontrolplanes/status
     verbs:
       - create
       - update
@@ -63,6 +61,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiocontrolplanes/status
+      - peeristiocontrolplanes/status
+    verbs:
+      - get
+      - update
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
@@ -27,6 +27,23 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    cluster-registry.k8s.cisco.com/reader-aggregated: "true"
+    release: istio-resource-sync-rule
+  name: mesh-reader-cp-v111x
+rules:
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiomeshes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
     cluster-registry.k8s.cisco.com/controller-aggregated: "true"
     release: istio-resource-sync-rule
   name: peeristiocontrolplane-controller-cp-v111x
@@ -106,6 +123,7 @@ spec:
     - match:
         objectKey:
           name: cp-v111x
+          namespace: istio-system
     - mutations:
         overrides:
           - parseValue: false

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-values.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-values.yaml
@@ -1,0 +1,3 @@
+revision: cp-v111x
+mode: ACTIVE
+distribution: cisco

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-values.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-values.yaml
@@ -1,3 +1,4 @@
 revision: cp-v111x
 mode: ACTIVE
 distribution: cisco
+meshID: mesh1

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
@@ -1,0 +1,115 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: istio-system
+spec: {}
+status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster-registry.k8s.cisco.com/controller-aggregated: "true"
+    release: istio-resource-sync-rule
+  name: istio-ca-root-cert-controller-cp-v111x
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster-registry.k8s.cisco.com/controller-aggregated: "true"
+    release: istio-resource-sync-rule
+  name: peeristiocontrolplane-controller-cp-v111x
+rules:
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiocontrolplanes
+      - peeristiocontrolplanes
+      - istiocontrolplanes/status
+      - peeristiocontrolplanes/status
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster-registry.k8s.cisco.com/reader-aggregated: "true"
+    release: istio-resource-sync-rule
+  name: peeristiocontrolplane-reader-cp-v111x
+rules:
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiocontrolplanes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ResourceSyncRule
+metadata:
+  annotations:
+    cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
+  labels:
+    release: istio-resource-sync-rule
+  name: istio-ca-root-cert-cp-v111x
+spec:
+  groupVersionKind:
+    kind: ConfigMap
+    version: v1
+  rules:
+    - match:
+        objectKey:
+          name: istio-ca-root-cert-cp-v111x
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ResourceSyncRule
+metadata:
+  annotations:
+    cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
+  labels:
+    release: istio-resource-sync-rule
+  name: peeristiocontrolplane-cp-v111x
+spec:
+  groupVersionKind:
+    group: servicemesh.cisco.com
+    kind: IstioControlPlane
+    version: v1alpha1
+  rules:
+    - match:
+        objectKey:
+          name: cp-v111x
+    - mutations:
+        overrides:
+          - parseValue: false
+            path: /kind
+            type: replace
+            value: PeerIstioControlPlane
+          - parseValue: false
+            path: /metadata/name
+            type: replace
+            value: printf "%s-%s" .Object.GetName .Cluster.GetName
+        syncStatus: true

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
@@ -39,7 +39,6 @@ rules:
       - servicemesh.cisco.com
     resources:
       - istiomeshes
-      - istiomeshes/status
     verbs:
       - create
       - update
@@ -48,6 +47,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiomeshes/status
+    verbs:
+      - get
+      - update
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -62,8 +69,6 @@ rules:
     resources:
       - istiocontrolplanes
       - peeristiocontrolplanes
-      - istiocontrolplanes/status
-      - peeristiocontrolplanes/status
     verbs:
       - create
       - update
@@ -72,6 +77,15 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiocontrolplanes/status
+      - peeristiocontrolplanes/status
+    verbs:
+      - get
+      - update
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
@@ -33,6 +33,28 @@ metadata:
   labels:
     cluster-registry.k8s.cisco.com/controller-aggregated: "true"
     release: istio-resource-sync-rule
+  name: mesh-controller-cp-v111x
+rules:
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiomeshes
+      - istiomeshes/status
+    verbs:
+      - create
+      - update
+      - delete
+      - patch
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster-registry.k8s.cisco.com/controller-aggregated: "true"
+    release: istio-resource-sync-rule
   name: peeristiocontrolplane-controller-cp-v111x
 rules:
   - apiGroups:
@@ -92,6 +114,26 @@ metadata:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: istio-resource-sync-rule
+  name: mesh-cp-v111x
+spec:
+  groupVersionKind:
+    group: servicemesh.cisco.com
+    kind: IstioMesh
+    version: v1alpha1
+  rules:
+    - match:
+        objectKey:
+          name: mesh1
+          namespace: istio-system
+        syncStatus: true
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ResourceSyncRule
+metadata:
+  annotations:
+    cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
+  labels:
+    release: istio-resource-sync-rule
   name: peeristiocontrolplane-cp-v111x
 spec:
   groupVersionKind:
@@ -102,6 +144,7 @@ spec:
     - match:
         objectKey:
           name: cp-v111x
+          namespace: istio-system
     - mutations:
         overrides:
           - parseValue: false

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
@@ -118,7 +118,7 @@ spec:
     version: v1
   rules:
     - match:
-        objectKey:
+      - objectKey:
           name: istio-ca-root-cert-cp-v111x
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -136,7 +136,7 @@ spec:
     version: v1alpha1
   rules:
     - match:
-        objectKey:
+      - objectKey:
           name: mesh1
           namespace: istio-system
         syncStatus: true
@@ -156,7 +156,7 @@ spec:
     version: v1alpha1
   rules:
     - match:
-        objectKey:
+      - objectKey:
           name: cp-v111x
           namespace: istio-system
     - mutations:
@@ -168,5 +168,5 @@ spec:
           - parseValue: false
             path: /metadata/name
             type: replace
-            value: printf "%s-%s" .Object.GetName .Cluster.GetName
+            value: '{{ printf "%s-%s" .Object.GetName .Cluster.GetName }}'
         syncStatus: true

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
@@ -31,6 +31,23 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
+    cluster-registry.k8s.cisco.com/reader-aggregated: "true"
+    release: istio-resource-sync-rule
+  name: istio-ca-root-cert-reader-cp-v111x
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
     cluster-registry.k8s.cisco.com/controller-aggregated: "true"
     release: istio-resource-sync-rule
   name: mesh-controller-cp-v111x
@@ -55,6 +72,23 @@ rules:
       - get
       - update
       - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    cluster-registry.k8s.cisco.com/reader-aggregated: "true"
+    release: istio-resource-sync-rule
+  name: mesh-reader-cp-v111x
+rules:
+  - apiGroups:
+      - servicemesh.cisco.com
+    resources:
+      - istiomeshes
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-values.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-values.yaml
@@ -1,3 +1,4 @@
 revision: cp-v111x
 mode: PASSIVE
 distribution: cisco
+meshID: mesh1

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-values.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-values.yaml
@@ -1,0 +1,3 @@
+revision: cp-v111x
+mode: PASSIVE
+distribution: cisco

--- a/internal/models/cluster_registry.go
+++ b/internal/models/cluster_registry.go
@@ -18,9 +18,14 @@ package models
 
 // ClusterRegistryConfiguration contains the settings to cooperate with the cluster registry APIs
 type ClusterRegistryConfiguration struct {
-	ClusterAPI ClusterAPIConfiguration `json:"clusterApi,omitempty"`
+	ClusterAPI        ClusterAPIConfiguration        `json:"clusterApi,omitempty"`
+	ResourceSyncRules ResourceSyncRulesConfiguration `json:"resourceSyncRules,omitempty"`
 }
 
 type ClusterAPIConfiguration struct {
+	Enabled bool `json:"enabled,omitempty"`
+}
+
+type ResourceSyncRulesConfiguration struct {
 	Enabled bool `json:"enabled,omitempty"`
 }

--- a/main.go
+++ b/main.go
@@ -65,10 +65,11 @@ func main() {
 	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "istio-system", "Determines the namespace in which the leader election configmap will be created.")
 	var leaderElectionName string
 	flag.StringVar(&leaderElectionName, "leader-election-name", "istio-operator-leader-election", "Determines the name of the leader election configmap.")
-	var clusterRegistryConfiguration models.ClusterRegistryConfiguration
-	flag.BoolVar(&clusterRegistryConfiguration.ClusterAPI.Enabled, "cluster-registry-api-enabled", false, "Enable using cluster registry API from the cluster when applicable.")
 	var apiServerEndpointAddress string
 	flag.StringVar(&apiServerEndpointAddress, "apiserver-endpoint-address", "", "Endpoint address of the API server of the cluster the controller is running on.")
+	var clusterRegistryConfiguration models.ClusterRegistryConfiguration
+	flag.BoolVar(&clusterRegistryConfiguration.ClusterAPI.Enabled, "cluster-registry-api-enabled", false, "Enable using cluster registry API from the cluster when applicable.")
+	flag.BoolVar(&clusterRegistryConfiguration.ResourceSyncRules.Enabled, "cluster-registry-sync-rules-enabled", false, "Enable automatically creating the necessary ResourceSyncRule resources from the cluster registry API for multi cluster setups.")
 	var webhookServerPort uint
 	flag.UintVar(&webhookServerPort, "webhook-server-port", 9443, "The port that the webhook server serves at.")
 	var verboseLogging bool


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Added a new reconciler component to reconcile `ResourceSyncRule` resources
- Added a `--cluster-registry-sync-rules-enabled` flag to the operator to enable/disable the automatic creation of the `ResourceSyncRule` resources
- Add the necessary RBAC rules
- Added tests 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

With the Cluster Registry API and controller the single mesh multi cluster setup can be much easier installed. The operator automatically creates these `ResourceSyncRule` resources so that the cluster-registry controller can keep in sync every necessary resource for this multi cluster setup.
 
### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
