### PR TITLE
[v2] Remove deprecated PodSecurityPolicy watcher

### DIFF
--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -400,12 +400,6 @@ func (r *IstioControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				APIVersion: corev1.SchemeGroupVersion.String(),
 			},
 		}, ctrlBuilder.WithPredicates(util.ObjectChangePredicate{})).
-		Owns(&policyv1beta1.PodSecurityPolicy{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "PodSecurityPolicy",
-				APIVersion: policyv1beta1.SchemeGroupVersion.String(),
-			},
-		}, ctrlBuilder.WithPredicates(util.ObjectChangePredicate{})).
 		Owns(&policyv1beta1.PodDisruptionBudget{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "PodDisruptionBudget",


### PR DESCRIPTION
### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

It's not necessary to watch `PodSecuritPolicies` and on k8s 1.21 we have this warning in the ICP controller: `{"level":"info","ts":"2021-09-23T08:02:35.486Z","logger":"KubeAPIWarningLogger","msg":"policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+"} `
