### PR TITLE
[v2] Enhance mesh expansion gateway load balancing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - wrapcheck
     - forbidigo
     - golint
+    - exhaustive
 
     # - goconst
     # - gocritic

--- a/config/samples/servicemesh_v1alpha1_istiocontrolplane.yaml
+++ b/config/samples/servicemesh_v1alpha1_istiocontrolplane.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   version: 1.11.0
   mode: ACTIVE
+  meshId: mesh1
   networkName: network1
   logging:
     level: "default:info"
@@ -105,7 +106,6 @@ spec:
       proxyAdminPort: 15000
       controlPlaneAuthPolicy: MUTUAL_TLS
       concurrency: 2
-      meshId: cluster.local
     outboundTrafficPolicy:
       mode: ALLOW_ANY
     enableAutoMtls: true

--- a/config/samples/servicemesh_v1alpha1_istiomesh.yaml
+++ b/config/samples/servicemesh_v1alpha1_istiomesh.yaml
@@ -1,4 +1,7 @@
 apiVersion: servicemesh.cisco.com/v1alpha1
 kind: IstioMesh
 metadata:
-  name: sample-mesh
+  name: mesh1
+spec:
+  config:
+    connectTimeout: 9s

--- a/internal/assets/manifests/istio-meshexpansion/templates/istio-meshexpansion-mgw.yaml
+++ b/internal/assets/manifests/istio-meshexpansion/templates/istio-meshexpansion-mgw.yaml
@@ -29,6 +29,12 @@ ports:
 env:
 - name: ISTIO_META_ROUTER_MODE
   value: sni-dnat
+- name: ISTIO_META_REQUESTED_NETWORK_VIEW
+  value: {{ .Values.network }}
+{{- if eq .Values.distribution "cisco" }}
+- name: ISTIO_META_LOCAL_ENDPOINTS_ONLY
+  value: "true"
+{{- end }}
 {{- include "toYamlIf" (dict "value" .Values.deployment.env) }}
 {{- end }}
 

--- a/internal/assets/manifests/istio-meshexpansion/values.yaml
+++ b/internal/assets/manifests/istio-meshexpansion/values.yaml
@@ -1,4 +1,6 @@
 revision: ""
+network: network1
+distribution: official
 
 exposeIstiod: true
 exposeWebhook: true

--- a/internal/assets/manifests/istio-meshexpansion/values.yaml.tpl
+++ b/internal/assets/manifests/istio-meshexpansion/values.yaml.tpl
@@ -13,3 +13,5 @@
 {{- if .GetSpec.GetMode }}
 mode: {{ .GetSpec.GetMode | toString }}
 {{- end }}
+{{ valueIf (dict "key" "distribution" "value" .GetSpec.GetDistribution) }}
+{{ valueIf (dict "key" "network" "value" .GetSpec.GetNetworkName) }}

--- a/internal/components/meshexpansion/testdata/icp-test-cr.yaml
+++ b/internal/components/meshexpansion/testdata/icp-test-cr.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   version: "1.11.0"
   mode: ACTIVE
+  networkName: network-bogus
+  distribution: cisco
   meshExpansion:
     enabled: true
     istiod:

--- a/internal/components/meshexpansion/testdata/mex-expected-resource-dump.yaml
+++ b/internal/components/meshexpansion/testdata/mex-expected-resource-dump.yaml
@@ -105,6 +105,10 @@ spec:
     env:
     - name: ISTIO_META_ROUTER_MODE
       value: sni-dnat
+    - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+      value: network-bogus
+    - name: ISTIO_META_LOCAL_ENDPOINTS_ONLY
+      value: "true"
     - name: ISTIO_BOGUS_ENV
       value: "true"
   service:

--- a/internal/components/meshexpansion/testdata/mex-expected-values.yaml
+++ b/internal/components/meshexpansion/testdata/mex-expected-values.yaml
@@ -1,4 +1,6 @@
 revision: cp-v111x
+network: network-bogus
+distribution: cisco
 exposeClusterServices: true
 exposeIstiod: true
 exposeWebhook: true

--- a/pkg/k8sutil/services.go
+++ b/pkg/k8sutil/services.go
@@ -63,7 +63,7 @@ func GetServiceEndpointIPs(service corev1.Service) ([]string, bool, error) {
 		return ips, true, nil
 	}
 
-	switch service.Spec.Type { // nolint:exhaustive
+	switch service.Spec.Type {
 	case corev1.ServiceTypeClusterIP:
 		if service.Spec.ClusterIP != corev1.ClusterIPNone {
 			ips = []string{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add two env vars: `ISTIO_META_REQUESTED_NETWORK_VIEW` and `ISTIO_META_LOCAL_ENDPOINTS_ONLY` to the mesh expansion IstioMeshGateway deployment.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

`ISTIO_META_REQUESTED_NETWORK_VIEW`: Helps to make sure that target endpoints are only selected from the same network. This way when a request comes through the mesh expansion gateway it will not be targeted to any other network on different clusters.

`ISTIO_META_LOCAL_ENDPOINTS_ONLY`: With this env var we only target endpoints on the same cluster when coming through the mesh expansion gateway. Since the mesh expansion gateway is a special ingress gateway designed to be only used for cross cluster traffic, it makes sense to only have local endpoints and this way avoid bouncing between other mesh expansion gateway endpoints. *This env var is only available in the Cisco Istio distribution.* 
