### PR TITLE
[v2] Add ClusterFeature CRs and matchers

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -162,13 +162,7 @@ rules:
 - apiGroups:
   - clusterregistry.k8s.cisco.com
   resources:
-  - clusters
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - clusterregistry.k8s.cisco.com
-  resources:
+  - clusterfeatures
   - resourcesyncrules
   verbs:
   - create
@@ -177,6 +171,13 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - clusterregistry.k8s.cisco.com
+  resources:
+  - clusters
+  verbs:
+  - list
   - watch
 - apiGroups:
   - coordination.k8s.io

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -474,6 +474,23 @@ func (r *IstioControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
+	if r.ClusterRegistry.ResourceSyncRules.Enabled {
+		types = append(types, []client.Object{
+			&clusterregistryv1alpha1.ResourceSyncRule{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ResourceSyncRule",
+					APIVersion: clusterregistryv1alpha1.SchemeBuilder.GroupVersion.String(),
+				},
+			},
+			&clusterregistryv1alpha1.ClusterFeature{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ClusterFeature",
+					APIVersion: clusterregistryv1alpha1.SchemeBuilder.GroupVersion.String(),
+				},
+			},
+		}...)
+	}
+
 	for _, t := range types {
 		err := r.ctrl.Watch(&source.Kind{Type: t}, handler.EnqueueRequestsFromMapFunc(reconciler.EnqueueByOwnerAnnotationMapper()), util.ObjectChangePredicate{})
 		if err != nil {

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -124,7 +124,7 @@ type IstioControlPlaneReconciler struct {
 // +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes;peeristiocontrolplanes;istiomeshes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=servicemesh.cisco.com,resources=istiocontrolplanes/status;peeristiocontrolplanes/status;istiomeshes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=clusterregistry.k8s.cisco.com,resources=clusters,verbs=list;watch
-// +kubebuilder:rbac:groups=clusterregistry.k8s.cisco.com,resources=resourcesyncrules,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=clusterregistry.k8s.cisco.com,resources=resourcesyncrules;clusterfeatures,verbs=get;list;watch;create;update;patch;delete
 
 func (r *IstioControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("istiocontrolplane", req.NamespacedName)

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -825,7 +825,7 @@ func (r *IstioControlPlaneReconciler) reconcileClusterReaderSecret(ctx context.C
 		},
 	}
 
-	if icp.DeletionTimestamp.IsZero() && icp.GetSpec().GetMode() == servicemeshv1alpha1.ModeType_PASSIVE {
+	if icp.DeletionTimestamp.IsZero() {
 		state = reconciler.StatePresent
 		secret, err = pkgUtil.GetReaderSecretForCluster(
 			ctx,

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -359,6 +359,7 @@ func (r *IstioControlPlaneReconciler) GetScheme() *runtime.Scheme {
 	return r.Scheme
 }
 
+//nolint: gocognit
 func (r *IstioControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.builder = ctrl.NewControllerManagedBy(mgr)
 
@@ -716,6 +717,7 @@ func (r *IstioControlPlaneReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 
+	// nolint:nestif
 	if r.ClusterRegistry.ResourceSyncRules.Enabled {
 		err = r.ctrl.Watch(
 			&source.Kind{

--- a/deploy/charts/istio-operator/templates/operator-rbac.yaml
+++ b/deploy/charts/istio-operator/templates/operator-rbac.yaml
@@ -172,13 +172,7 @@ rules:
 - apiGroups:
   - clusterregistry.k8s.cisco.com
   resources:
-  - clusters
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - clusterregistry.k8s.cisco.com
-  resources:
+  - clusterfeatures
   - resourcesyncrules
   verbs:
   - create
@@ -187,6 +181,13 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - clusterregistry.k8s.cisco.com
+  resources:
+  - clusters
+  verbs:
+  - list
   - watch
 - apiGroups:
   - coordination.k8s.io

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	emperror.dev/errors v0.8.0
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
-	github.com/banzaicloud/cluster-registry v0.0.5
+	github.com/banzaicloud/cluster-registry v0.0.7
 	github.com/banzaicloud/istio-operator/v2/api v0.0.1
 	github.com/banzaicloud/k8s-objectmatcher v1.5.2
 	github.com/banzaicloud/operator-tools v0.24.1-0.20210917222015-90c6c0b3cffe

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/banzaicloud/cluster-registry v0.0.5 h1:mUfDexjyAtrZ6Ylqp0/55u2G4ie0Ea5iYUDTdeh39yw=
-github.com/banzaicloud/cluster-registry v0.0.5/go.mod h1:2tcT4bq6UaWOOeIBsjcrqawOfrybamYUJSM4jRVHQic=
+github.com/banzaicloud/cluster-registry v0.0.7 h1:R7hE9YBybCWKOJSzrNPDIO+l8P03kGiaqMfhI68+BCA=
+github.com/banzaicloud/cluster-registry v0.0.7/go.mod h1:2tcT4bq6UaWOOeIBsjcrqawOfrybamYUJSM4jRVHQic=
 github.com/banzaicloud/k8s-objectmatcher v1.5.0/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
 github.com/banzaicloud/k8s-objectmatcher v1.5.1/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
 github.com/banzaicloud/k8s-objectmatcher v1.5.2 h1:wY3YBAVnh36Gm957IIlvtZbKVXbg4b+6fwrhoTz3opE=

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-cluster-feature.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-cluster-feature.yaml
@@ -2,10 +2,10 @@
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ClusterFeature
 metadata:
-  name: {{ include "name-with-revision" (dict "name" "istio-ca-root-cert" "context" $) }}
+  name: {{ include "name-with-revision" (dict "name" "istio.servicemesh.cisco.com/ca-root-cert-source" "context" $) }}
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ include "namespaced-revision" . }}
 spec:
-  featureName: "istio-ca-root-cert"
+  featureName: "istio.servicemesh.cisco.com/ca-root-cert-source"
 {{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-cluster-feature.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-cluster-feature.yaml
@@ -1,0 +1,11 @@
+{{- if eq .Values.mode "ACTIVE" }}
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "istio-ca-root-cert" "context" $) }}
+  labels:
+    release: {{ .Release.Name }}
+    istio.io/rev: {{ include "namespaced-revision" . }}
+spec:
+  featureName: "istio-ca-root-cert"
+{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-resource-sync-rule.yaml
@@ -8,6 +8,10 @@ metadata:
   labels:
     release: {{ .Release.Name }}
 spec:
+  clusterFeatureMatch:
+  - featureName: "istio-ca-root-cert"
+    matchLabels:
+      istio.io/rev: {{ include "namespaced-revision" . }}
   groupVersionKind:
     kind: ConfigMap
     version: v1

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-ca-root-cert-resource-sync-rule.yaml
@@ -2,14 +2,14 @@
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
 metadata:
-  name: {{ include "name-with-revision" (dict "name" "istio-ca-root-cert" "context" $) }}
+  name: {{ include "name-with-revision" (dict "name" "istio.servicemesh.cisco.com/ca-root-cert-sink" "context" $) }}
   annotations:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: {{ .Release.Name }}
 spec:
   clusterFeatureMatch:
-  - featureName: "istio-ca-root-cert"
+  - featureName: "istio.servicemesh.cisco.com/ca-root-cert-source"
     matchLabels:
       istio.io/rev: {{ include "namespaced-revision" . }}
   groupVersionKind:

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-cluster-feature.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-cluster-feature.yaml
@@ -1,0 +1,9 @@
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "istio-multi-cluster-secret" "context" $) }}
+  labels:
+    release: {{ .Release.Name }}
+    istio.io/rev: {{ include "namespaced-revision" . }}
+spec:
+  featureName: "istio-multi-cluster-secret"

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-cluster-feature.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-cluster-feature.yaml
@@ -1,9 +1,9 @@
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ClusterFeature
 metadata:
-  name: {{ include "name-with-revision" (dict "name" "istio-multi-cluster-secret" "context" $) }}
+  name: {{ include "name-with-revision" (dict "name" "istio.servicemesh.cisco.com/multi-cluster-secret-source" "context" $) }}
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ include "namespaced-revision" . }}
 spec:
-  featureName: "istio-multi-cluster-secret"
+  featureName: "istio.servicemesh.cisco.com/multi-cluster-secret-source"

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
@@ -8,6 +8,10 @@ metadata:
   labels:
     release: {{ .Release.Name }}
 spec:
+  clusterFeatureMatch:
+    - featureName: "istio-multi-cluster-secret"
+      matchLabels:
+        istio.io/rev: {{ include "namespaced-revision" . }}
   groupVersionKind:
     kind: Secret
     version: v1

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
@@ -2,14 +2,14 @@
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
 metadata:
-  name: {{ include "name-with-revision" (dict "name" "istio-multi-cluster-secret" "context" $) }}
+  name: {{ include "name-with-revision" (dict "name" "istio.servicemesh.cisco.com/multi-cluster-secret-sink" "context" $) }}
   annotations:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: {{ .Release.Name }}
 spec:
   clusterFeatureMatch:
-    - featureName: "istio-multi-cluster-secret"
+    - featureName: "istio.servicemesh.cisco.com/multi-cluster-secret-source"
       matchLabels:
         istio.io/rev: {{ include "namespaced-revision" . }}
   groupVersionKind:

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-cluster-feature.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-cluster-feature.yaml
@@ -2,10 +2,10 @@
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ClusterFeature
 metadata:
-  name: {{ include "name-with-revision" (dict "name" "mesh" "context" $) }}
+  name: {{ include "name-with-revision" (dict "name" "istio.servicemesh.cisco.com/mesh-source" "context" $) }}
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ include "namespaced-revision" . }}
 spec:
-  featureName: "mesh"
+  featureName: "istio.servicemesh.cisco.com/mesh-source"
 {{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-cluster-feature.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-cluster-feature.yaml
@@ -1,0 +1,11 @@
+{{- if eq .Values.mode "ACTIVE" }}
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "mesh" "context" $) }}
+  labels:
+    release: {{ .Release.Name }}
+    istio.io/rev: {{ include "namespaced-revision" . }}
+spec:
+  featureName: "mesh"
+{{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
@@ -8,6 +8,10 @@ metadata:
   labels:
     release: {{ .Release.Name }}
 spec:
+  clusterFeatureMatch:
+    - featureName: "mesh"
+      matchLabels:
+        istio.io/rev: {{ include "namespaced-revision" . }}
   groupVersionKind:
     group: servicemesh.cisco.com
     kind: IstioMesh

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
@@ -2,14 +2,14 @@
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
 metadata:
-  name: {{ include "name-with-revision" (dict "name" "mesh" "context" $) }}
+  name: {{ include "name-with-revision" (dict "name" "istio.servicemesh.cisco.com/mesh-sink" "context" $) }}
   annotations:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: {{ .Release.Name }}
 spec:
   clusterFeatureMatch:
-    - featureName: "mesh"
+    - featureName: "istio.servicemesh.cisco.com/mesh-source"
       matchLabels:
         istio.io/rev: {{ include "namespaced-revision" . }}
   groupVersionKind:

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-cluster-feature.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-cluster-feature.yaml
@@ -1,9 +1,9 @@
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ClusterFeature
 metadata:
-  name: {{ include "name-with-revision" (dict "name" "peeristiocontrolplane" "context" $) }}
+  name: {{ include "name-with-revision" (dict "name" "istio.servicemesh.cisco.com/peeristiocontrolplane-source" "context" $) }}
   labels:
     release: {{ .Release.Name }}
     istio.io/rev: {{ include "namespaced-revision" . }}
 spec:
-  featureName: "peeristiocontrolplane"
+  featureName: "istio.servicemesh.cisco.com/peeristiocontrolplane-source"

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-cluster-feature.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-cluster-feature.yaml
@@ -1,0 +1,9 @@
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  name: {{ include "name-with-revision" (dict "name" "peeristiocontrolplane" "context" $) }}
+  labels:
+    release: {{ .Release.Name }}
+    istio.io/rev: {{ include "namespaced-revision" . }}
+spec:
+  featureName: "peeristiocontrolplane"

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
@@ -20,12 +20,10 @@ spec:
     - objectKey:
         name: {{ .Values.revision }}
         namespace: {{ .Release.Namespace }}
-  - mutations:
+    mutations:
+      groupVersionKind:
+        kind: PeerIstioControlPlane
       overrides:
-        - parseValue: false
-          path: /kind
-          type: replace
-          value: PeerIstioControlPlane
         - parseValue: false
           path: /metadata/name
           type: replace

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
@@ -1,14 +1,14 @@
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
 metadata:
-  name: {{ include "name-with-revision" (dict "name" "peeristiocontrolplane" "context" $) }}
+  name: {{ include "name-with-revision" (dict "name" "istio.servicemesh.cisco.com/peeristiocontrolplane-sink" "context" $) }}
   annotations:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: {{ .Release.Name }}
 spec:
   clusterFeatureMatch:
-    - featureName: "peeristiocontrolplane"
+    - featureName: "istio.servicemesh.cisco.com/peeristiocontrolplane-source"
       matchLabels:
         istio.io/rev: {{ include "namespaced-revision" . }}
   groupVersionKind:

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     release: {{ .Release.Name }}
 spec:
+  clusterFeatureMatch:
+    - featureName: "peeristiocontrolplane"
+      matchLabels:
+        istio.io/rev: {{ include "namespaced-revision" . }}
   groupVersionKind:
     group: servicemesh.cisco.com
     kind: IstioControlPlane

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
@@ -94,9 +94,9 @@ metadata:
   labels:
     istio.io/rev: cp-v111x.istio-system
     release: istio-resource-sync-rule
-  name: istio-ca-root-cert-cp-v111x
+  name: istio.servicemesh.cisco.com/ca-root-cert-source-cp-v111x
 spec:
-  featureName: istio-ca-root-cert
+  featureName: istio.servicemesh.cisco.com/ca-root-cert-source
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ClusterFeature
@@ -104,9 +104,9 @@ metadata:
   labels:
     istio.io/rev: cp-v111x.istio-system
     release: istio-resource-sync-rule
-  name: istio-multi-cluster-secret-cp-v111x
+  name: istio.servicemesh.cisco.com/mesh-source-cp-v111x
 spec:
-  featureName: istio-multi-cluster-secret
+  featureName: istio.servicemesh.cisco.com/mesh-source
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ClusterFeature
@@ -114,9 +114,9 @@ metadata:
   labels:
     istio.io/rev: cp-v111x.istio-system
     release: istio-resource-sync-rule
-  name: mesh-cp-v111x
+  name: istio.servicemesh.cisco.com/multi-cluster-secret-source-cp-v111x
 spec:
-  featureName: mesh
+  featureName: istio.servicemesh.cisco.com/multi-cluster-secret-source
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ClusterFeature
@@ -124,9 +124,9 @@ metadata:
   labels:
     istio.io/rev: cp-v111x.istio-system
     release: istio-resource-sync-rule
-  name: peeristiocontrolplane-cp-v111x
+  name: istio.servicemesh.cisco.com/peeristiocontrolplane-source-cp-v111x
 spec:
-  featureName: peeristiocontrolplane
+  featureName: istio.servicemesh.cisco.com/peeristiocontrolplane-source
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -135,10 +135,10 @@ metadata:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: istio-resource-sync-rule
-  name: istio-multi-cluster-secret-cp-v111x
+  name: istio.servicemesh.cisco.com/multi-cluster-secret-sink-cp-v111x
 spec:
   clusterFeatureMatch:
-    - featureName: istio-multi-cluster-secret
+    - featureName: istio.servicemesh.cisco.com/multi-cluster-secret-source
       matchLabels:
         istio.io/rev: cp-v111x.istio-system
   groupVersionKind:
@@ -164,10 +164,10 @@ metadata:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: istio-resource-sync-rule
-  name: peeristiocontrolplane-cp-v111x
+  name: istio.servicemesh.cisco.com/peeristiocontrolplane-sink-cp-v111x
 spec:
   clusterFeatureMatch:
-    - featureName: peeristiocontrolplane
+    - featureName: istio.servicemesh.cisco.com/peeristiocontrolplane-source
       matchLabels:
         istio.io/rev: cp-v111x.istio-system
   groupVersionKind:

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
@@ -89,6 +89,46 @@ rules:
       - watch
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  labels:
+    istio.io/rev: cp-v111x.istio-system
+    release: istio-resource-sync-rule
+  name: istio-ca-root-cert-cp-v111x
+spec:
+  featureName: istio-ca-root-cert
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  labels:
+    istio.io/rev: cp-v111x.istio-system
+    release: istio-resource-sync-rule
+  name: istio-multi-cluster-secret-cp-v111x
+spec:
+  featureName: istio-multi-cluster-secret
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  labels:
+    istio.io/rev: cp-v111x.istio-system
+    release: istio-resource-sync-rule
+  name: mesh-cp-v111x
+spec:
+  featureName: mesh
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  labels:
+    istio.io/rev: cp-v111x.istio-system
+    release: istio-resource-sync-rule
+  name: peeristiocontrolplane-cp-v111x
+spec:
+  featureName: peeristiocontrolplane
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
 metadata:
   annotations:
@@ -97,17 +137,21 @@ metadata:
     release: istio-resource-sync-rule
   name: istio-multi-cluster-secret-cp-v111x
 spec:
+  clusterFeatureMatch:
+    - featureName: istio-multi-cluster-secret
+      matchLabels:
+        istio.io/rev: cp-v111x.istio-system
   groupVersionKind:
     kind: Secret
     version: v1
   rules:
     - match:
-      - content:
-          - key: type
-            value: k8s.cisco.com/istio-reader-secret
-        labels:
-          - matchLabels:
-              istio.io/rev: cp-v111x.istio-system
+        - content:
+            - key: type
+              value: k8s.cisco.com/istio-reader-secret
+          labels:
+            - matchLabels:
+                istio.io/rev: cp-v111x.istio-system
       mutations:
         labels:
           add:
@@ -122,15 +166,19 @@ metadata:
     release: istio-resource-sync-rule
   name: peeristiocontrolplane-cp-v111x
 spec:
+  clusterFeatureMatch:
+    - featureName: peeristiocontrolplane
+      matchLabels:
+        istio.io/rev: cp-v111x.istio-system
   groupVersionKind:
     group: servicemesh.cisco.com
     kind: IstioControlPlane
     version: v1alpha1
   rules:
     - match:
-      - objectKey:
-          name: cp-v111x
-          namespace: istio-system
+        - objectKey:
+            name: cp-v111x
+            namespace: istio-system
     - mutations:
         overrides:
           - parseValue: false

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
@@ -179,12 +179,10 @@ spec:
         - objectKey:
             name: cp-v111x
             namespace: istio-system
-    - mutations:
+      mutations:
+        groupVersionKind:
+          kind: PeerIstioControlPlane
         overrides:
-          - parseValue: false
-            path: /kind
-            type: replace
-            value: PeerIstioControlPlane
           - parseValue: false
             path: /metadata/name
             type: replace

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
@@ -139,6 +139,26 @@ rules:
       - watch
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  labels:
+    istio.io/rev: cp-v111x.istio-system
+    release: istio-resource-sync-rule
+  name: istio-multi-cluster-secret-cp-v111x
+spec:
+  featureName: istio-multi-cluster-secret
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
+kind: ClusterFeature
+metadata:
+  labels:
+    istio.io/rev: cp-v111x.istio-system
+    release: istio-resource-sync-rule
+  name: peeristiocontrolplane-cp-v111x
+spec:
+  featureName: peeristiocontrolplane
+---
+apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
 metadata:
   annotations:
@@ -147,13 +167,17 @@ metadata:
     release: istio-resource-sync-rule
   name: istio-ca-root-cert-cp-v111x
 spec:
+  clusterFeatureMatch:
+    - featureName: istio-ca-root-cert
+      matchLabels:
+        istio.io/rev: cp-v111x.istio-system
   groupVersionKind:
     kind: ConfigMap
     version: v1
   rules:
     - match:
-      - objectKey:
-          name: istio-ca-root-cert-cp-v111x
+        - objectKey:
+            name: istio-ca-root-cert-cp-v111x
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -164,16 +188,20 @@ metadata:
     release: istio-resource-sync-rule
   name: mesh-cp-v111x
 spec:
+  clusterFeatureMatch:
+    - featureName: mesh
+      matchLabels:
+        istio.io/rev: cp-v111x.istio-system
   groupVersionKind:
     group: servicemesh.cisco.com
     kind: IstioMesh
     version: v1alpha1
   rules:
     - match:
-      - objectKey:
-          name: mesh1
-          namespace: istio-system
-        syncStatus: true
+        - objectKey:
+            name: mesh1
+            namespace: istio-system
+          syncStatus: true
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -184,15 +212,19 @@ metadata:
     release: istio-resource-sync-rule
   name: peeristiocontrolplane-cp-v111x
 spec:
+  clusterFeatureMatch:
+    - featureName: peeristiocontrolplane
+      matchLabels:
+        istio.io/rev: cp-v111x.istio-system
   groupVersionKind:
     group: servicemesh.cisco.com
     kind: IstioControlPlane
     version: v1alpha1
   rules:
     - match:
-      - objectKey:
-          name: cp-v111x
-          namespace: istio-system
+        - objectKey:
+            name: cp-v111x
+            namespace: istio-system
     - mutations:
         overrides:
           - parseValue: false

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
@@ -225,12 +225,10 @@ spec:
         - objectKey:
             name: cp-v111x
             namespace: istio-system
-    - mutations:
+      mutations:
+        groupVersionKind:
+          kind: PeerIstioControlPlane
         overrides:
-          - parseValue: false
-            path: /kind
-            type: replace
-            value: PeerIstioControlPlane
           - parseValue: false
             path: /metadata/name
             type: replace

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
@@ -144,9 +144,9 @@ metadata:
   labels:
     istio.io/rev: cp-v111x.istio-system
     release: istio-resource-sync-rule
-  name: istio-multi-cluster-secret-cp-v111x
+  name: istio.servicemesh.cisco.com/multi-cluster-secret-source-cp-v111x
 spec:
-  featureName: istio-multi-cluster-secret
+  featureName: istio.servicemesh.cisco.com/multi-cluster-secret-source
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ClusterFeature
@@ -154,9 +154,9 @@ metadata:
   labels:
     istio.io/rev: cp-v111x.istio-system
     release: istio-resource-sync-rule
-  name: peeristiocontrolplane-cp-v111x
+  name: istio.servicemesh.cisco.com/peeristiocontrolplane-source-cp-v111x
 spec:
-  featureName: peeristiocontrolplane
+  featureName: istio.servicemesh.cisco.com/peeristiocontrolplane-source
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -165,10 +165,10 @@ metadata:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: istio-resource-sync-rule
-  name: istio-ca-root-cert-cp-v111x
+  name: istio.servicemesh.cisco.com/ca-root-cert-sink-cp-v111x
 spec:
   clusterFeatureMatch:
-    - featureName: istio-ca-root-cert
+    - featureName: istio.servicemesh.cisco.com/ca-root-cert-source
       matchLabels:
         istio.io/rev: cp-v111x.istio-system
   groupVersionKind:
@@ -186,10 +186,10 @@ metadata:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: istio-resource-sync-rule
-  name: mesh-cp-v111x
+  name: istio.servicemesh.cisco.com/mesh-sink-cp-v111x
 spec:
   clusterFeatureMatch:
-    - featureName: mesh
+    - featureName: istio.servicemesh.cisco.com/mesh-source
       matchLabels:
         istio.io/rev: cp-v111x.istio-system
   groupVersionKind:
@@ -210,10 +210,10 @@ metadata:
     cluster-registry.k8s.cisco.com/resource-sync-disabled: "true"
   labels:
     release: istio-resource-sync-rule
-  name: peeristiocontrolplane-cp-v111x
+  name: istio.servicemesh.cisco.com/peeristiocontrolplane-sink-cp-v111x
 spec:
   clusterFeatureMatch:
-    - featureName: peeristiocontrolplane
+    - featureName: istio.servicemesh.cisco.com/peeristiocontrolplane-source
       matchLabels:
         istio.io/rev: cp-v111x.istio-system
   groupVersionKind:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Istio operator now installs `ResourceSyncRules` with  `clusterFeatureMatch` matchers and also installs `ClusterFeature` CRs where needed.

Also now the istio operator creates secret for the k8s cluster kubeconfig on all clusters (ACTIVE as well), because it will be needed for ACTIVE-ACTIVE setups. 

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

There are cases when we wouldn't like to sync some resources from all of the other "known" clusters from ClusterRegistry. To solve this issue, `ClusterFeature` CRs are added to the appropriate places where we would like to sync from.

An example is when there is a new cluster in the "known" cluster list, but that new cluster does not have istio operator installed yet. In that case, without the `clusterFeatureMatch` matchers, the cluster-registry-controllers would try to sync from the new cluster even though that might not have the necessary `ClusterRoles` installed yet and fail. With the `ClusterFeatureMatch` matches this will not happen, because until there is no `ClusterFeature` CR installed on the new cluster, the cluster-registry-controller will not try to sync from that.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
