### PR TITLE
[v2] Automate release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,35 @@
 version: 2.1
 orbs:
   helm: banzaicloud/helm@0.0.8
+  docker: banzaicloud/docker@0.0.5
 
 executors:
   helm311:
     docker:
       - image: ghcr.io/banzaicloud/helm:0.0.7
+
+commands:
+  publish-with-latests:
+    steps:
+      - docker/push:
+          registry: ghcr.io
+          image: banzaicloud/istio-operator
+          tag: ${CIRCLE_TAG}
+      - docker/version-check:
+          version: ${CIRCLE_TAG}
+          halt: true
+      - run:
+          name: Publish latest
+          command: |
+            minor="$(echo ${CIRCLE_TAG} | cut -d '.' -f2)"
+            docker tag "banzaicloud/istio-operator:${CIRCLE_TAG}" "ghcr.io/banzaicloud/istio-operator:latest-1.${minor}"
+            docker push "ghcr.io/banzaicloud/istio-operator:latest-1.${minor}"
+
+            latest="$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | cut -d '.' -f2 | sort -urn | head -n 1)"
+            if [ "${latest}" -eq "${minor}" ]; then
+              docker tag "banzaicloud/istio-operator:${CIRCLE_TAG}" "ghcr.io/banzaicloud/istio-operator:latest"
+              docker push "ghcr.io/banzaicloud/istio-operator:latest"
+            fi
 
 jobs:
   build:
@@ -68,6 +92,31 @@ workflows:
     jobs:
     - build
 
+    - docker/build:
+        name: Build docker image
+        executor: docker/machine-dlc
+        image: banzaicloud/istio-operator
+        tag: ${CIRCLE_BRANCH//\//-}
+        filters:
+          tags:
+            ignore: /.*/
+
+    - docker/custom-publish:
+        name: Publish tagged & latest docker image
+        executor: docker/machine-dlc
+        context:
+          - github
+        image: banzaicloud/istio-operator
+        login:
+          - docker/ghcr-login
+        push:
+          - publish-with-latests
+        filters:
+          tags:
+            only: /^v?[0-9]+\.[0-9]+\.[0-9]+(?:-(?:dev|rc)\.[0-9]+)?$/
+          branches:
+            ignore: /.*/
+
   helm-chart:
     jobs:
       - helm/lint-chart:
@@ -76,3 +125,13 @@ workflows:
           filters:
             tags:
               ignore: /.*/
+
+      - helm/publish-chart:
+          context: helm
+          executor: helm311
+          charts-dir: deploy/charts
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /deploy\/charts\/\d+.\d+.\d+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,4 +134,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /deploy\/charts\/\d+.\d+.\d+/
+              only: /deploy\/charts\/v?\d+.\d+.\d+/

--- a/Makefile
+++ b/Makefile
@@ -155,4 +155,6 @@ release: check_release
 	git tag -a ${REL_TAG} -m ${RELEASE_MSG}
 	git tag -a ${API_REL_TAG} -m ${API_RELEASE_MSG}
 	git tag -a ${CHART_REL_TAG} -m ${CHART_RELEASE_MSG}
-	git push origin ${REL_TAG} ${API_REL_TAG} ${CHART_REL_TAG}
+	git push origin ${REL_TAG}
+	git push origin ${API_REL_TAG}
+	git push origin ${CHART_REL_TAG}

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ TAG ?= $(shell git describe --tags --abbrev=0 --match '[0-9].*[0-9].*[0-9]' 2>/d
 IMAGE_REPOSITORY ?= banzaicloud/istio-operator
 IMG ?= ${IMAGE_REPOSITORY}:$(TAG)
 
+CHART_VERSION ?= $(shell sed -nr '/version:/ s/.*version: ([^"]+).*/\1/p' deploy/charts/istio-operator/Chart.yaml)
+
 RELEASE_TYPE ?= p
 RELEASE_MSG ?= "istio operator release"
 API_RELEASE_MSG ?= "istio operator api release"
@@ -10,7 +12,7 @@ CHART_RELEASE_MSG ?= "istio operator chart release"
 
 REL_TAG = $(shell ./scripts/increment_version.sh -${RELEASE_TYPE} ${TAG})
 API_REL_TAG ?= api/${REL_TAG}
-CHART_REL_TAG ?= deploy/charts/${REL_TAG}
+CHART_REL_TAG ?= deploy/charts/v${CHART_VERSION}
 
 GOLANGCI_VERSION = 1.42.1
 LICENSEI_VERSION = 0.4.0

--- a/deploy/charts/istio-operator/Chart.yaml
+++ b/deploy/charts/istio-operator/Chart.yaml
@@ -12,4 +12,4 @@ icon: https://istio.io/latest/img/istio-whitelogo-bluebackground-framed.svg
 kubeVersion: ">= 1.19.0-0 < 1.23.0-0"
 
 version: 2.0.0
-appVersion: "v2.11.0"
+appVersion: "v2.11.0-rc.0"

--- a/deploy/charts/istio-operator/README.md
+++ b/deploy/charts/istio-operator/README.md
@@ -33,7 +33,7 @@ The following table lists the configurable parameters of the Banzaicloud Istio O
 Parameter | Description | Default
 --------- | ----------- | -------
 `image.repository` | Operator container image repository | `ghcr.io/banzaicloud/istio-operator`
-`image.tag` | Operator container image tag | `v2.11.0`
+`image.tag` | Operator container image tag | `v2.11.0-rc.0`
 `image.pullPolicy` | Operator container image pull policy | `IfNotPresent`
 `replicaCount` | Operator deployment replica count | `1`
 `extraArgs` | Operator deployment arguments | `[]`

--- a/deploy/charts/istio-operator/values.yaml
+++ b/deploy/charts/istio-operator/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/banzaicloud/istio-operator
-  tag: "v2.11.0"
+  tag: "v2.11.0-rc.0"
   pullPolicy: IfNotPresent
 replicaCount: 1
 extraArgs: []

--- a/scripts/increment_version.sh
+++ b/scripts/increment_version.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+while getopts ":Mmp" opt; do
+  case $opt in
+    M )
+      relType="major"
+      ;;
+    m )
+      relType="minor"
+      ;;
+    p )
+      relType="patch"
+      ;;
+    *)
+      echo "Unexpected flag: -$opt"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z $relType ]; then
+  echo "usage: $(basename "$0") [-Mmp] major.minor.patch"
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  echo "usage: $(basename "$0") [-Mmp] major.minor.patch"
+  exit 1
+fi
+
+version=$2
+# shellcheck disable=SC2206
+parts=( ${version//./ } )
+
+if [ $relType == "major" ]; then
+  ((parts[0]++))
+  parts[1]=0
+  parts[2]=0
+fi
+
+if [ $relType == "minor" ]; then
+  ((parts[1]++))
+  parts[2]=0
+fi
+
+if [ $relType == "patch" ]; then
+  ((parts[2]++))
+fi
+
+echo "${parts[0]}.${parts[1]}.${parts[2]}"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Added a `make release` command to automatically push tags like this:

- `v2.11.0`
- `api/v2.11.0`
- `deploy/charts/v2.0.0`

These GO modules can be imported from other projects.

Based on the tags, CircleCI publishes the following Docker images:

- tag (e.g. `v2.11.0`)
- latest-1.<minor> (e.g. `latest-1.11`)
- latest

CircleCI publishes the Helm chart as well.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

To be able to release Docker images, Helm charts and go modules can be imported from other projects.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

- For the Helm charts we need a tag to trigger a helm chart publish. For the GO embedded chart variable to use a specific chart version we need a tag to be able to use a specific chart version from other GO codes. My suggestion is to use the same tag for these two purposes, e.g. `deploy/charts/v2.0.0`. Placing will trigger a Helm chart publish and can be used right away from other GO codes as well to use the same chart.

- Only `ghcr` images are published, `docker.io` is not used.
