### PR TITLE
[v2] Fix sidecar-injector deployment/pod labels

### DIFF
--- a/internal/assets/manifests/istio-sidecar-injector/templates/_helpers.tpl
+++ b/internal/assets/manifests/istio-sidecar-injector/templates/_helpers.tpl
@@ -25,9 +25,10 @@
 
 {{- define "generic.labels" }}
 release: {{ .Release.Name }}
+istio: "sidecar-injector"
 app: "istio-sidecar-injector"
 {{- if .Values.revision }}
-istio.io/rev: {{ .Values.revision }}
+istio.io/rev: {{ include "namespaced-revision" . }}
 {{- end }}
 {{- end }}
 

--- a/internal/components/sidecarinjector/testdata/icp-expected-resource-dump.yaml
+++ b/internal/components/sidecarinjector/testdata/icp-expected-resource-dump.yaml
@@ -9,13 +9,14 @@ status: {}
 ---
 apiVersion: v1
 imagePullSecrets:
-- name: pullsecret-1
-- name: pullsecret-2
+  - name: pullsecret-1
+  - name: pullsecret-2
 kind: ServiceAccount
 metadata:
   labels:
     app: istio-sidecar-injector
-    istio.io/rev: cp-v111x
+    istio: sidecar-injector
+    istio.io/rev: cp-v111x.istio-system
     release: istio-sidecar-injector
   name: istio-sidecar-injector-cp-v111x
   namespace: istio-system
@@ -29,24 +30,24 @@ metadata:
     release: istio-sidecar-injector
   name: istio-sidecar-injector-cp-v111x-istio-system
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  verbs:
-  - get
-  - list
-  - watch
-  - update
-  - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -61,9 +62,9 @@ roleRef:
   kind: ClusterRole
   name: istio-sidecar-injector-cp-v111x-istio-system
 subjects:
-- kind: ServiceAccount
-  name: istio-sidecar-injector-cp-v111x
-  namespace: istio-system
+  - kind: ServiceAccount
+    name: istio-sidecar-injector-cp-v111x
+    namespace: istio-system
 
 ---
 apiVersion: v1
@@ -71,23 +72,25 @@ kind: Service
 metadata:
   labels:
     app: istio-sidecar-injector
-    istio.io/rev: cp-v111x
+    istio: sidecar-injector
+    istio.io/rev: cp-v111x.istio-system
     release: istio-sidecar-injector
   name: istio-sidecar-injector-cp-v111x
   namespace: istio-system
 spec:
   ports:
-  - name: https-inject
-    port: 443
-    protocol: TCP
-    targetPort: 9443
-  - name: http-monitoring
-    port: 15014
-    protocol: TCP
-    targetPort: 15014
+    - name: https-inject
+      port: 443
+      protocol: TCP
+      targetPort: 9443
+    - name: http-monitoring
+      port: 15014
+      protocol: TCP
+      targetPort: 15014
   selector:
     app: istio-sidecar-injector
-    istio.io/rev: cp-v111x
+    istio: sidecar-injector
+    istio.io/rev: cp-v111x.istio-system
     podlabel: podlabelvalue
     release: istio-sidecar-injector
   type: ClusterIP
@@ -100,7 +103,8 @@ metadata:
     daemonset-annotation: value
   labels:
     app: istio-sidecar-injector
-    istio.io/rev: cp-v111x
+    istio: sidecar-injector
+    istio.io/rev: cp-v111x.istio-system
     release: istio-sidecar-injector
   name: istio-sidecar-injector-cp-v111x
   namespace: istio-system
@@ -109,7 +113,8 @@ spec:
   selector:
     matchLabels:
       app: istio-sidecar-injector
-      istio.io/rev: cp-v111x
+      istio: sidecar-injector
+      istio.io/rev: cp-v111x.istio-system
       podlabel: podlabelvalue
       release: istio-sidecar-injector
   strategy:
@@ -125,7 +130,8 @@ spec:
         sidecar.istio.io/inject: "false"
       labels:
         app: istio-sidecar-injector
-        istio.io/rev: cp-v111x
+        istio: sidecar-injector
+        istio.io/rev: cp-v111x.istio-system
         podlabel: podlabelvalue
         release: istio-sidecar-injector
         sidecar.istio.io/inject: "false"
@@ -134,106 +140,106 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/e2e-az-name
-                operator: In
-                values:
-                - e2e-az1
-                - e2e-az2
+              - matchExpressions:
+                  - key: kubernetes.io/e2e-az-name
+                    operator: In
+                    values:
+                      - e2e-az1
+                      - e2e-az2
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: security
-                operator: In
-                values:
-                - S1
-            topologyKey: topology.kubernetes.io/zone
+            - labelSelector:
+                matchExpressions:
+                  - key: security
+                    operator: In
+                    values:
+                      - S1
+              topologyKey: topology.kubernetes.io/zone
       containers:
-      - args:
-        - --caCertFile=/etc/istio/certs/ca.crt
-        - --tlsCertFile=/etc/istio/certs/tls.crt
-        - --tlsKeyFile=/etc/istio/certs/tls.key
-        - --injectConfig=/etc/istio/inject/config
-        - --meshConfig=/etc/istio/config/mesh
-        - --healthCheckInterval=2s
-        - --healthCheckFile=/tmp/health
-        - --reconcileWebhookConfig=true
-        - --webhookConfigName=istio-sidecar-injector-cp-v111x-istio-system
-        env:
-        - name: REVISION
-          value: cp-v111x.istio-system
-        - name: CERT_DNS_NAMES
-          value: istio-sidecar-injector-cp-v111x.istio-system,istio-sidecar-injector-cp-v111x.istio-system.svc,istio-sidecar-injector-cp-v111x.istio-system.svc.cluster.local
-        - name: CNI_ENV_NAME
-          value: "true"
-        - name: CNI_ANOTHER_ENV_NAME
-          value: standard
-        image: banzaicloud/istio-sidecar-injector:v1.10.4-bzc.1
-        imagePullPolicy: Always
-        name: sidecar-injector-webhook
-        ports:
-        - containerPort: 9443
-          protocol: TCP
-        - containerPort: 15014
-          protocol: TCP
-        - containerPort: 15090
-          name: http-envoy-prom
-          protocol: TCP
-        livenessProbe:
-          exec:
-            command:
-            - /usr/local/bin/sidecar-injector
-            - probe
-            - --probe-path=/tmp/health
-            - --interval=4s
-          failureThreshold: 3
-          initialDelaySeconds: 15
-          periodSeconds: 4
-          successThreshold: 1
-          timeoutSeconds: 1
-        readinessProbe:
-          exec:
-            command:
-            - /usr/local/bin/sidecar-injector
-            - probe
-            - --probe-path=/tmp/health
-            - --interval=4s
-          failureThreshold: 3
-          initialDelaySeconds: 4
-          periodSeconds: 4
-          successThreshold: 1
-          timeoutSeconds: 1
-        resources:
-          limits:
-            cpu: "3"
-            memory: 2Gi
-          requests:
-            cpu: 100m
-            memory: 128Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          runAsGroup: 1337
-          runAsNonRoot: true
-          runAsUser: 1337
-        volumeMounts:
-        - mountPath: /etc/istio/config
-          name: config-volume
-          readOnly: true
-        - mountPath: /etc/istio/certs
-          name: certs
-          readOnly: false
-        - mountPath: /etc/istio/inject
-          name: inject-config
-        - mountPath: /var/run/secrets/tokens
-          name: istio-token
-          readOnly: true
-        - mountPath: /etc/config
-          name: config-vol
+        - args:
+            - --caCertFile=/etc/istio/certs/ca.crt
+            - --tlsCertFile=/etc/istio/certs/tls.crt
+            - --tlsKeyFile=/etc/istio/certs/tls.key
+            - --injectConfig=/etc/istio/inject/config
+            - --meshConfig=/etc/istio/config/mesh
+            - --healthCheckInterval=2s
+            - --healthCheckFile=/tmp/health
+            - --reconcileWebhookConfig=true
+            - --webhookConfigName=istio-sidecar-injector-cp-v111x-istio-system
+          env:
+            - name: REVISION
+              value: cp-v111x.istio-system
+            - name: CERT_DNS_NAMES
+              value: istio-sidecar-injector-cp-v111x.istio-system,istio-sidecar-injector-cp-v111x.istio-system.svc,istio-sidecar-injector-cp-v111x.istio-system.svc.cluster.local
+            - name: CNI_ENV_NAME
+              value: "true"
+            - name: CNI_ANOTHER_ENV_NAME
+              value: standard
+          image: banzaicloud/istio-sidecar-injector:v1.10.4-bzc.1
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /usr/local/bin/sidecar-injector
+                - probe
+                - --probe-path=/tmp/health
+                - --interval=4s
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 4
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: sidecar-injector-webhook
+          ports:
+            - containerPort: 9443
+              protocol: TCP
+            - containerPort: 15014
+              protocol: TCP
+            - containerPort: 15090
+              name: http-envoy-prom
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /usr/local/bin/sidecar-injector
+                - probe
+                - --probe-path=/tmp/health
+                - --interval=4s
+            failureThreshold: 3
+            initialDelaySeconds: 4
+            periodSeconds: 4
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: "3"
+              memory: 2Gi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            runAsGroup: 1337
+            runAsNonRoot: true
+            runAsUser: 1337
+          volumeMounts:
+            - mountPath: /etc/istio/config
+              name: config-volume
+              readOnly: true
+            - mountPath: /etc/istio/certs
+              name: certs
+              readOnly: false
+            - mountPath: /etc/istio/inject
+              name: inject-config
+            - mountPath: /var/run/secrets/tokens
+              name: istio-token
+              readOnly: true
+            - mountPath: /etc/config
+              name: config-vol
       nodeSelector:
         disktype: ssd
       priorityClassName: system-node-critical
@@ -244,42 +250,42 @@ spec:
         runAsUser: 1337
       serviceAccountName: istio-sidecar-injector-cp-v111x
       tolerations:
-      - effect: NoSchedule
-        key: key1
-        operator: Equal
-        tolerationSeconds: 5
-        value: value1
+        - effect: NoSchedule
+          key: key1
+          operator: Equal
+          tolerationSeconds: 5
+          value: value1
       volumes:
-      - configMap:
-          defaultMode: 420
-          name: istio-cp-v111x
-        name: config-volume
-      - configMap:
-          defaultMode: 420
-          items:
-          - key: config
-            path: config
-          - key: values
-            path: values
-          name: istio-sidecar-injector-cp-v111x
-        name: inject-config
-      - emptyDir:
-          medium: Memory
-        name: certs
-      - name: istio-token
-        projected:
-          sources:
-          - serviceAccountToken:
-              audience: istio-ca
-              expirationSeconds: 43200
-              path: istio-token
-      - name: dddemo
-        secret:
-          optional: true
-          secretName: ssname
-      - configMap:
-          items:
-          - key: log_level
-            path: log_level
-          name: log-config
-        name: config-vol
+        - configMap:
+            defaultMode: 420
+            name: istio-cp-v111x
+          name: config-volume
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config
+                path: config
+              - key: values
+                path: values
+            name: istio-sidecar-injector-cp-v111x
+          name: inject-config
+        - emptyDir:
+            medium: Memory
+          name: certs
+        - name: istio-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  audience: istio-ca
+                  expirationSeconds: 43200
+                  path: istio-token
+        - name: dddemo
+          secret:
+            optional: true
+            secretName: ssname
+        - configMap:
+            items:
+              - key: log_level
+                path: log_level
+            name: log-config
+          name: config-vol


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Fix `istio.io/rev` label for `sidecar-injector` deployment/pod so that it contains the namespace as well
- Add `istio: sidecar-injector` label to `sidecar-injector` deployment/pod so that it is conform with other usual istio labels and if other projects depend on this label it's there (e.g. SMM checks if pod is running based on this label as well)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
