### PR TITLE
[v2] remove deprecated injection label when reconcile injection labels

### DIFF
--- a/api/v1alpha1/istiocontrolplane_types.go
+++ b/api/v1alpha1/istiocontrolplane_types.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	RevisionedAutoInjectionLabel       = "istio.io/rev"
+	DeprecatedAutoInjectionLabel       = "istio-injection"
 	NamespaceInjectionSourceAnnotation = "controlplane.istio.servicemesh.cisco.com/namespace-injection-source"
 )
 

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -1167,7 +1167,9 @@ func (r *IstioControlPlaneReconciler) reconcileNamespaceInjectionLabels(ctx cont
 		if err != nil {
 			return errors.WrapIfWithDetails(err, "could not get namespace", "namespace", name)
 		}
-		ns.SetLabels(utils.MergeLabels(ns.GetLabels(), icp.RevisionLabels()))
+		labels := utils.MergeLabels(ns.GetLabels(), icp.RevisionLabels())
+		delete(labels, servicemeshv1alpha1.DeprecatedAutoInjectionLabel)
+		ns.SetLabels(labels)
 		r.Log.Info("add injection label to namespace", "namespace", ns.GetName(), "label", servicemeshv1alpha1.RevisionedAutoInjectionLabel)
 		err = r.GetClient().Update(ctx, ns)
 		if err != nil {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0
