### PR TITLE
Fix publishing latest docker images and helm charts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,4 +134,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /deploy\/charts\/v?\d+.\d+.\d+/
+              only: /chart\/istio-operator\/\d+.\d+.\d+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,12 +22,12 @@ commands:
           name: Publish latest
           command: |
             minor="$(echo ${CIRCLE_TAG} | cut -d '.' -f2)"
-            docker tag "banzaicloud/istio-operator:${CIRCLE_TAG}" "ghcr.io/banzaicloud/istio-operator:latest-1.${minor}"
+            docker tag "ghcr.io/banzaicloud/istio-operator:${CIRCLE_TAG}" "ghcr.io/banzaicloud/istio-operator:latest-1.${minor}"
             docker push "ghcr.io/banzaicloud/istio-operator:latest-1.${minor}"
 
             latest="$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | cut -d '.' -f2 | sort -urn | head -n 1)"
             if [ "${latest}" -eq "${minor}" ]; then
-              docker tag "banzaicloud/istio-operator:${CIRCLE_TAG}" "ghcr.io/banzaicloud/istio-operator:latest"
+              docker tag "ghcr.io/banzaicloud/istio-operator:${CIRCLE_TAG}" "ghcr.io/banzaicloud/istio-operator:latest"
               docker push "ghcr.io/banzaicloud/istio-operator:latest"
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
             docker tag "ghcr.io/banzaicloud/istio-operator:${CIRCLE_TAG}" "ghcr.io/banzaicloud/istio-operator:latest-1.${minor}"
             docker push "ghcr.io/banzaicloud/istio-operator:latest-1.${minor}"
 
-            latest="$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | cut -d '.' -f2 | sort -urn | head -n 1)"
+            latest="$(git tag | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | cut -d '.' -f2 | sort -urn | head -n 1)"
             if [ "${latest}" -eq "${minor}" ]; then
               docker tag "ghcr.io/banzaicloud/istio-operator:${CIRCLE_TAG}" "ghcr.io/banzaicloud/istio-operator:latest"
               docker push "ghcr.io/banzaicloud/istio-operator:latest"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-TAG ?= $(shell git describe --tags --abbrev=0 --match '[0-9].*[0-9].*[0-9]' 2>/dev/null )
+TAG ?= $(shell git describe --tags --abbrev=0 --match 'v[0-9].*[0-9].*[0-9]' 2>/dev/null )
 IMAGE_REPOSITORY ?= banzaicloud/istio-operator
 IMG ?= ${IMAGE_REPOSITORY}:$(TAG)
 

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,13 @@ CHART_VERSION ?= $(shell sed -nr '/version:/ s/.*version: ([^"]+).*/\1/p' deploy
 RELEASE_TYPE ?= p
 RELEASE_MSG ?= "istio operator release"
 API_RELEASE_MSG ?= "istio operator api release"
-CHART_RELEASE_MSG ?= "istio operator chart release"
+EMBEDDED_CHART_RELEASE_MSG ?= "istio operator embedded chart release"
+HELM_CHART_RELEASE_MSG ?= "istio operator helm chart release"
 
 REL_TAG = $(shell ./scripts/increment_version.sh -${RELEASE_TYPE} ${TAG})
 API_REL_TAG ?= api/${REL_TAG}
-CHART_REL_TAG ?= deploy/charts/v${CHART_VERSION}
+EMBEDDED_CHART_REL_TAG ?= deploy/charts/v${CHART_VERSION}
+HELM_CHART_REL_TAG ?= chart/istio-operator/${CHART_VERSION}
 
 GOLANGCI_VERSION = 1.42.1
 LICENSEI_VERSION = 0.4.0
@@ -149,12 +151,14 @@ docker-push:
 	docker push ${IMG}
 
 check_release:
-	@echo "New tags (${REL_TAG}, ${API_REL_TAG} and ${CHART_REL_TAG}) will be pushed to Github, a new Docker image (${REL_TAG}) will be released, and a new Helm chart (${CHART_REL_TAG}) will be released. Are you sure? [y/N] " && read -r ans && [ "$${ans:-N}" = y ]
+	@echo "New tags (${REL_TAG}, ${API_REL_TAG}, ${EMBEDDED_CHART_REL_TAG} and ${HELM_CHART_REL_TAG}) will be pushed to Github, a new Docker image (${REL_TAG}) will be released, and a new Helm chart (${HELM_CHART_REL_TAG}) will be released. Are you sure? [y/N] " && read -r ans && [ "$${ans:-N}" = y ]
 
 release: check_release
 	git tag -a ${REL_TAG} -m ${RELEASE_MSG}
 	git tag -a ${API_REL_TAG} -m ${API_RELEASE_MSG}
-	git tag -a ${CHART_REL_TAG} -m ${CHART_RELEASE_MSG}
+	git tag -a ${EMBEDDED_CHART_REL_TAG} -m ${EMBEDDED_CHART_RELEASE_MSG}
+	git tag -a ${HELM_CHART_REL_TAG} -m ${HELM_CHART_RELEASE_MSG}
 	git push origin ${REL_TAG}
 	git push origin ${API_REL_TAG}
-	git push origin ${CHART_REL_TAG}
+	git push origin ${EMBEDDED_CHART_REL_TAG}
+	git push origin ${HELM_CHART_REL_TAG}


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

- Fix local docker image name in CI
- Fix git tag regex in CI and Makefile
- Add new tag for helm chart releases and adjust CI to that

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

- Latest Docker image published failed like this: https://app.circleci.com/pipelines/github/banzaicloud/istio-operator/2655/workflows/1b0c71d0-4cac-4965-b424-bb37be5f645f/jobs/5269. Issue was that `"banzaicloud/istio-operator:${CIRCLE_TAG}"` docker image is not present locally on the CI, because we don't push to DockerHub anymore, only to GHCR. To fix that the local name was changed to `"ghcr.io/banzaicloud/istio-operator:${CIRCLE_TAG}"`.
- Git tag regex was also fixed because we now use tags starting with `v`.
- Helm publish failed like this: https://app.circleci.com/pipelines/github/banzaicloud/istio-operator/2656/workflows/8f2f864c-871f-4b25-baa9-cb83a6e63d50/jobs/5268. Our helm chart tag format, `deploy/charts/v2.0.0`, did not have the directory name for the exact helm chart like `istio-operator.` We need to have it in the tag name for helm publish, but we cannot have it for the go module tag. For that reason, from now on we publish two separate tags, one for Helm publish and one for Go module, so that charts can be embedded:
  - The `deploy/charts/v<VERSION>` tag stays as is for Go modules
  - The new `chart/istio-operator/<VERSION>` tag will be used by the CI to be able to publish Helm charts
