### PR TITLE
Fix crd delete func predicate logic

### DIFF
--- a/pkg/crds/crds.go
+++ b/pkg/crds/crds.go
@@ -265,7 +265,7 @@ func GetWatchPredicateForCRDs() predicate.Funcs {
 			if e.Object.GetLabels()[createdByLabel] == managedBy || e.Object.GetLabels()[types.ManagedByLabel] == managedBy {
 				return true
 			}
-			return true
+			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			if e.ObjectOld.GetLabels()[createdByLabel] == managedBy || e.ObjectNew.GetLabels()[createdByLabel] == managedBy {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
If the CRD is not owned by our istio-operator, the deletion of the CRD shouldn't trigger the reconcile logic

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
The original implementation would try to create the deleted istio CRDs even they are not managed by us

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
