### PR TITLE
support additional external service for istio mesh gateways

### DIFF
--- a/api/v1alpha1/istiomeshgateway_types.go
+++ b/api/v1alpha1/istiomeshgateway_types.go
@@ -79,12 +79,13 @@ func (p *IstioMeshGatewayWithProperties) SetDefaults() {
 }
 
 type IstioMeshGatewayProperties struct {
-	Revision              string
-	EnablePrometheusMerge *bool
-	InjectionTemplate     string
-	InjectionChecksum     string
-	MeshConfigChecksum    string
-	IstioControlPlane     *IstioControlPlane
+	Revision                string
+	EnablePrometheusMerge   *bool
+	InjectionTemplate       string
+	InjectionChecksum       string
+	MeshConfigChecksum      string
+	IstioControlPlane       *IstioControlPlane
+	GenerateExternalService bool
 }
 
 func (p IstioMeshGatewayProperties) GetIstioControlPlane() *IstioControlPlane {

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -1250,7 +1250,7 @@ func (r *IstioControlPlaneReconciler) getNamespaceInjectionSourcePICP(ctx contex
 	var sourceICP *servicemeshv1alpha1.PeerIstioControlPlane
 	for _, picp := range picpList.Items {
 		picp := picp
-		if v, ok := picp.GetAnnotations()[servicemeshv1alpha1.NamespaceInjectionSourceAnnotation]; ok && v == "true" && picp.Status.IstioControlPlaneName == cp.Name {
+		if v, ok := picp.GetAnnotations()[servicemeshv1alpha1.NamespaceInjectionSourceAnnotation]; ok && v == "true" && picp.Status.IstioControlPlaneName == cp.Name { // nolint:goconst
 			sourceICP = &picp
 		}
 	}

--- a/internal/assets/manifests/istio-meshexpansion/templates/istio-meshexpansion-mgw.yaml
+++ b/internal/assets/manifests/istio-meshexpansion/templates/istio-meshexpansion-mgw.yaml
@@ -42,6 +42,8 @@ apiVersion: servicemesh.cisco.com/v1alpha1
 kind: IstioMeshGateway
 metadata:
   name: {{ include "name-with-revision" (dict "name" "istio-meshexpansion" "context" $) }}
+  annotations:
+    meshgateway.istio.servicemesh.cisco.com/generate-external-service: "true"
   labels:
     istio.io/rev: {{ include "namespaced-revision" . }}
     app: istio-meshexpansion-gateway

--- a/internal/assets/manifests/istio-meshgateway/templates/service-ext.yaml
+++ b/internal/assets/manifests/istio-meshgateway/templates/service-ext.yaml
@@ -1,0 +1,42 @@
+{{- $gateway := .Values.deployment }}
+{{- $service := .Values.service -}}
+{{- if and .Values.externalService.addresses (eq $service.type "LoadBalancer") }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $gateway.name }}-external
+  namespace: {{ .Release.Namespace }}
+  labels:
+    meshgateway.istio.servicemesh.cisco.com/external-service: "true"
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    {{- range $key, $val := $service.ports }}
+    -
+      {{- range $pkey, $pval := $val }}
+      {{ $pkey}}: {{ $pval }}
+      {{- end }}
+    {{- end }}
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ $gateway.name }}-external
+  namespace: {{ .Release.Namespace }}
+  labels:
+    meshgateway.istio.servicemesh.cisco.com/external-service: "true"
+subsets:
+- addresses:
+  {{- range $val := .Values.externalService.addresses }}
+  - ip: {{ $val }}
+  {{- end }}
+  ports:
+    {{- range $key, $val := $service.ports }}
+    -
+      {{- range $pkey, $pval := $val }}
+      {{ $pkey}}: {{ $pval }}
+      {{- end }}
+    {{- end }}
+---
+{{- end }}

--- a/internal/assets/manifests/istio-meshgateway/values.yaml
+++ b/internal/assets/manifests/istio-meshgateway/values.yaml
@@ -50,6 +50,9 @@ service:
   ports: []
   selector: {}
 
+externalService:
+  addresses: {}
+
 global:
   imagePullPolicy: "IfNotPresent"
   imagePullSecrets: []

--- a/internal/assets/manifests/istio-meshgateway/values.yaml.tpl
+++ b/internal/assets/manifests/istio-meshgateway/values.yaml.tpl
@@ -52,3 +52,10 @@ service:
 {{ toYamlIf (dict "value" .GetSessionAffinityConfig "key" "sessionAffinityConfig") | indent 2 }}
 {{ valueIf (dict "value" .GetIpFamily "key" "ipFamily") | indent 2 }}
 {{- end }}
+
+{{- if $.Properties.GenerateExternalService }}
+{{- with $.Status.GetGatewayAddress }}
+externalService:
+{{ toYamlIf (dict "value" . "key" "addresses") | indent 2 }}
+{{- end }}
+{{- end }}

--- a/internal/components/istiomeshgateway/istiomeshgateway_test.go
+++ b/internal/components/istiomeshgateway/istiomeshgateway_test.go
@@ -66,12 +66,13 @@ func TestIMGWResourceDump(t *testing.T) {
 			reconciler.NativeReconcilerSetControllerRef(),
 		}),
 		v1alpha1.IstioMeshGatewayProperties{
-			Revision:              "cp-v110x.istio-system",
-			EnablePrometheusMerge: utils.BoolPointer(true),
-			InjectionTemplate:     "gateway",
-			InjectionChecksum:     "08fdba0c89f9bbd6624201d98758746d1bddc78e9004b00259f33b20b7f9efba",
-			MeshConfigChecksum:    "319ffd3f807ef4516499c6ad68279a1cd07778f5847e65f9aef908eceb1693e3",
-			IstioControlPlane:     icp,
+			Revision:                "cp-v110x.istio-system",
+			EnablePrometheusMerge:   utils.BoolPointer(true),
+			InjectionTemplate:       "gateway",
+			InjectionChecksum:       "08fdba0c89f9bbd6624201d98758746d1bddc78e9004b00259f33b20b7f9efba",
+			MeshConfigChecksum:      "319ffd3f807ef4516499c6ad68279a1cd07778f5847e65f9aef908eceb1693e3",
+			IstioControlPlane:       icp,
+			GenerateExternalService: true,
 		},
 	)
 
@@ -114,12 +115,13 @@ func TestIMGWTemplateTransform(t *testing.T) {
 	obj := &v1alpha1.IstioMeshGatewayWithProperties{
 		IstioMeshGateway: imgw,
 		Properties: v1alpha1.IstioMeshGatewayProperties{
-			Revision:              "cp-revision-1",
-			EnablePrometheusMerge: utils.BoolPointer(false),
-			InjectionTemplate:     "gateway",
-			InjectionChecksum:     "08fdba0c89f9bbd6624201d98758746d1bddc78e9004b00259f33b20b7f9efba",
-			MeshConfigChecksum:    "319ffd3f807ef4516499c6ad68279a1cd07778f5847e65f9aef908eceb1693e3",
-			IstioControlPlane:     icp,
+			Revision:                "cp-revision-1",
+			EnablePrometheusMerge:   utils.BoolPointer(false),
+			InjectionTemplate:       "gateway",
+			InjectionChecksum:       "08fdba0c89f9bbd6624201d98758746d1bddc78e9004b00259f33b20b7f9efba",
+			MeshConfigChecksum:      "319ffd3f807ef4516499c6ad68279a1cd07778f5847e65f9aef908eceb1693e3",
+			IstioControlPlane:       icp,
+			GenerateExternalService: true,
 		},
 	}
 	obj.SetDefaults()

--- a/internal/components/istiomeshgateway/testdata/imgw-expected-resource-dump.yaml
+++ b/internal/components/istiomeshgateway/testdata/imgw-expected-resource-dump.yaml
@@ -127,6 +127,27 @@ spec:
   type: LoadBalancer
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-gw-external
+  namespace: default
+  labels:
+    meshgateway.istio.servicemesh.cisco.com/external-service: "true"
+spec:
+  clusterIP: None
+  ports:
+  - name: tcp-als-tls
+    port: 50600
+    protocol: TCP
+    targetPort: 50600
+  - name: tcp-zipkin-tls
+    port: 59411
+    protocol: TCP
+    targetPort: 59411
+  type: ClusterIP
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -278,3 +299,24 @@ spec:
       resource:
         name: cpu
         targetAverageUtilization: 80
+
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: demo-gw-external
+  namespace: default
+  labels:
+    meshgateway.istio.servicemesh.cisco.com/external-service: "true"
+subsets:
+- addresses:
+  - ip: 34.147.29.25
+  ports:
+  - name: tcp-als-tls
+    port: 50600
+    protocol: TCP
+    targetPort: 50600
+  - name: tcp-zipkin-tls
+    port: 59411
+    protocol: TCP
+    targetPort: 59411

--- a/internal/components/istiomeshgateway/testdata/imgw-expected-values.yaml
+++ b/internal/components/istiomeshgateway/testdata/imgw-expected-values.yaml
@@ -136,3 +136,7 @@ service:
     clientIP:
       timeoutSeconds: 3600
   ipFamily: IPv4
+
+externalService:
+  addresses:
+  - 34.147.29.25

--- a/internal/components/istiomeshgateway/testdata/imgw-test-cr.yaml
+++ b/internal/components/istiomeshgateway/testdata/imgw-test-cr.yaml
@@ -148,3 +148,6 @@ spec:
           httpCookie:
             name: user
             ttl: 0s
+status:
+  GatewayAddress:
+  - 34.147.29.25


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Adds support to have an additional k8s headless service resource with name is suffixed with `-external` for istio mesh gateways configured as load balancer type. The additional service has static endpoints for the external ip address(es) of the mesh gateway.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The additional service is added to support use-cases where easy access is needed for the external address of any mesh gateway. The feature is automatically turned on for the mesh expansion gateway.

The feature is turned on with `meshgateway.istio.servicemesh.cisco.com/generate-external-service annotation on the imgw resource set to true.
