### PR TITLE
Omit resourceNames from signers approve RBAC rule

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -167,8 +167,6 @@ rules:
   - watch
 - apiGroups:
   - certificates.k8s.io
-  resourceNames:
-  - kubernetes.io/legacy-unknown
   resources:
   - signers
   verbs:

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -110,7 +110,7 @@ type IstioControlPlaneReconciler struct {
 // +kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups="autoscaling",resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="certificates.k8s.io",resources=certificatesigningrequests;certificatesigningrequests/approval;certificatesigningrequests/status,verbs=update;create;get;delete;watch
-// +kubebuilder:rbac:groups="certificates.k8s.io",resources=signers,resourceNames=kubernetes.io/legacy-unknown,verbs=approve
+// +kubebuilder:rbac:groups="certificates.k8s.io",resources=signers,verbs=approve
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;create;update
 // +kubebuilder:rbac:groups="discovery.k8s.io",resources=endpointslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups="extensions",resources=ingresses,verbs=get;list;watch

--- a/deploy/charts/istio-operator/templates/operator-rbac.yaml
+++ b/deploy/charts/istio-operator/templates/operator-rbac.yaml
@@ -177,8 +177,6 @@ rules:
   - watch
 - apiGroups:
   - certificates.k8s.io
-  resourceNames:
-  - kubernetes.io/legacy-unknown
   resources:
   - signers
   verbs:


### PR DESCRIPTION
### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Remove the `resourceNames` limitation for the signers approve RBAC rule in the operator.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

So that such use cases can be supported when different `resourceNames` are used for approvals for external CA setups.
