### PR TITLE
Fix #808

### DIFF
--- a/api/v1alpha1/istiocontrolplane.pb.go
+++ b/api/v1alpha1/istiocontrolplane.pb.go
@@ -185,7 +185,7 @@ func (JWTPolicyType) EnumDescriptor() ([]byte, []int) {
 // -->
 type IstioControlPlaneSpec struct {
 	// Contains the intended version for the Istio control plane.
-	// +kubebuilder:validation:Pattern=^1.
+	// +kubebuilder:validation:Pattern=^1\.
 	Version string `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`
 	// Configure the mode for this control plane.
 	// Currently, two options are supported: "ACTIVE" and "PASSIVE".

--- a/api/v1alpha1/istiocontrolplane.pb.html
+++ b/api/v1alpha1/istiocontrolplane.pb.html
@@ -25,7 +25,7 @@ number_of_entries: 39
 <td><code>string</code></td>
 <td>
 <p>Contains the intended version for the Istio control plane.
-+kubebuilder:validation:Pattern=^1.</p>
++kubebuilder:validation:Pattern=^1\.</p>
 
 </td>
 <td>

--- a/api/v1alpha1/istiocontrolplane.proto
+++ b/api/v1alpha1/istiocontrolplane.proto
@@ -60,7 +60,7 @@ option go_package = "github.com/banzaicloud/istio-operator/v2/api/v1alpha1";
 // -->
 message IstioControlPlaneSpec {
     // Contains the intended version for the Istio control plane.
-    // +kubebuilder:validation:Pattern=^1.
+    // +kubebuilder:validation:Pattern=^1\.
     string version = 1 [(google.api.field_behavior) = REQUIRED];
     // Configure the mode for this control plane.
     // Currently, two options are supported: "ACTIVE" and "PASSIVE".

--- a/config/crd/bases/istio-operator-crds.gen.yaml
+++ b/config/crd/bases/istio-operator-crds.gen.yaml
@@ -6379,7 +6379,7 @@ spec:
                       type: boolean
                   type: object
                 version:
-                  pattern: ^1.
+                  pattern: ^1\.
                   type: string
                 watchOneNamespace:
                   nullable: true
@@ -13704,7 +13704,7 @@ spec:
                       type: boolean
                   type: object
                 version:
-                  pattern: ^1.
+                  pattern: ^1\.
                   type: string
                 watchOneNamespace:
                   nullable: true

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -151,7 +151,7 @@ func (r *IstioControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		}, nil
 	}
 
-	if !isIstioVersionSupported(icp.Spec.Version) {
+	if !IsIstioVersionSupported(icp.Spec.Version) {
 		err = errors.New("intended Istio version is unsupported by this version of the operator")
 		logger.Error(err, "", "version", icp.Spec.Version)
 

--- a/controllers/meshgateway_controller.go
+++ b/controllers/meshgateway_controller.go
@@ -103,7 +103,7 @@ func (r *IstioMeshGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	if !isIstioVersionSupported(icp.Spec.Version) {
+	if !IsIstioVersionSupported(icp.Spec.Version) {
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/version.go
+++ b/controllers/version.go
@@ -19,7 +19,7 @@ package controllers
 import "regexp"
 
 const (
-	supportedIstioMinorVersionRegex = "^1\\.11"
+	supportedIstioMinorVersionRegex = "^1\\.11(\\.[0-9]+)?(-.+)?$"
 )
 
 func IsIstioVersionSupported(version string) bool {

--- a/controllers/version.go
+++ b/controllers/version.go
@@ -19,10 +19,10 @@ package controllers
 import "regexp"
 
 const (
-	supportedIstioMinorVersionRegex = "^1.11"
+	supportedIstioMinorVersionRegex = "^1\\.11"
 )
 
-func isIstioVersionSupported(version string) bool {
+func IsIstioVersionSupported(version string) bool {
 	re, _ := regexp.Compile(supportedIstioMinorVersionRegex)
 
 	return re.Match([]byte(version))

--- a/controllers/version_test.go
+++ b/controllers/version_test.go
@@ -9,14 +9,20 @@ import (
 
 var _ = Describe("IsIstioVersionSupported()", func() {
 	It("should deny unsupported versions", func() {
-		Expect(controllers.IsIstioVersionSupported("2.1")).To(BeFalse())
-		Expect(controllers.IsIstioVersionSupported("1.13")).To(BeFalse())
-		Expect(controllers.IsIstioVersionSupported("1.13.1")).To(BeFalse())
+		for _, version := range []string{"2.11", "2.11.1", "2.11.1-dev", "1.12", "1.12.1", "1.12.1-dev"} {
+			Expect(controllers.IsIstioVersionSupported(version)).To(BeFalse(), "invalid: "+version)
+		}
 	})
-	It("should accept minor versions", func() {
+	It("should accept all 1.11 versions", func() {
 		Expect(controllers.IsIstioVersionSupported("1.11")).To(BeTrue())
+	})
+	It("should accept all 1.11 versions with qualifier", func() {
+		Expect(controllers.IsIstioVersionSupported("1.11-dev")).To(BeTrue())
 	})
 	It("should accept micro versions", func() {
 		Expect(controllers.IsIstioVersionSupported("1.11.1")).To(BeTrue())
+	})
+	It("should accept micro versions with qualifier", func() {
+		Expect(controllers.IsIstioVersionSupported("1.11.1-dev")).To(BeTrue())
 	})
 })

--- a/controllers/version_test.go
+++ b/controllers/version_test.go
@@ -1,0 +1,22 @@
+package controllers_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/banzaicloud/istio-operator/v2/controllers"
+)
+
+var _ = Describe("IsIstioVersionSupported()", func() {
+	It("should deny unsupported versions", func() {
+		Expect(controllers.IsIstioVersionSupported("2.1")).To(BeFalse())
+		Expect(controllers.IsIstioVersionSupported("1.13")).To(BeFalse())
+		Expect(controllers.IsIstioVersionSupported("1.13.1")).To(BeFalse())
+	})
+	It("should accept minor versions", func() {
+		Expect(controllers.IsIstioVersionSupported("1.11")).To(BeTrue())
+	})
+	It("should accept micro versions", func() {
+		Expect(controllers.IsIstioVersionSupported("1.11.1")).To(BeTrue())
+	})
+})

--- a/deploy/charts/istio-operator/Chart.yaml
+++ b/deploy/charts/istio-operator/Chart.yaml
@@ -11,5 +11,5 @@ icon: https://istio.io/latest/img/istio-whitelogo-bluebackground-framed.svg
 # Based on support status of Istio releases: https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases
 kubeVersion: ">= 1.19.0-0 < 1.23.0-0"
 
-version: 2.0.5
+version: 2.0.6
 appVersion: "v2.11.5"

--- a/deploy/charts/istio-operator/crds/istio-operator-crds.gen.yaml
+++ b/deploy/charts/istio-operator/crds/istio-operator-crds.gen.yaml
@@ -6379,7 +6379,7 @@ spec:
                       type: boolean
                   type: object
                 version:
-                  pattern: ^1.
+                  pattern: ^1\.
                   type: string
                 watchOneNamespace:
                   nullable: true
@@ -13704,7 +13704,7 @@ spec:
                       type: boolean
                   type: object
                 version:
-                  pattern: ^1.
+                  pattern: ^1\.
                   type: string
                 watchOneNamespace:
                   nullable: true


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #808
| License         | Apache 2.0


### What's in this PR?
Improved matcher for supported istio versions


### Why?
IstioControlPlane was not usable setting 1.11 as version.



### Checklist
- [ X ] Implementation tested
- [ X ] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md) (N/A)
- [ X ] Logging code meets the guideline (N/A)
- [ X ] User guide and development docs updated (if needed) (N/A)
