### PR TITLE
Fix licensei

### DIFF
--- a/.licensei.toml
+++ b/.licensei.toml
@@ -41,7 +41,7 @@ ignoreFiles = [
 ]
 
 template = """/*
-Copyright 2021 Cisco Systems, Inc. and/or its affiliates.
+Copyright :YEAR: Cisco Systems, Inc. and/or its affiliates.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/api/v1alpha1/istiocontrolplane.pb.html
+++ b/api/v1alpha1/istiocontrolplane.pb.html
@@ -25,7 +25,7 @@ number_of_entries: 39
 <td><code>string</code></td>
 <td>
 <p>Contains the intended version for the Istio control plane.
-+kubebuilder:validation:Pattern=^1\.</p>
++kubebuilder:validation:Pattern=^1.</p>
 
 </td>
 <td>

--- a/controllers/version_test.go
+++ b/controllers/version_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 Cisco Systems, Inc. and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers_test
 
 import (


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets |
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Add missing license header to a GO test file and exclude escaping the `.` character in the generated html.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

So that CI passes.

### Additional context
<!-- Additional information we should know about (eg. edge cases, steps you followed to test the implementation) (Please remove this section if you don't need it) -->

Also changed `.licensei.toml` to accept any year in the license.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
