### PR TITLE
imgw: support spec.deployment.image override

### DIFF
--- a/internal/assets/manifests/istio-meshgateway/templates/deployment.yaml
+++ b/internal/assets/manifests/istio-meshgateway/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         {{- end }}
         sidecar.istio.io/inject: "true"
         inject.istio.io/templates: "{{ .Values.injectionTemplate }}"
-        {{- if contains "/" $gateway.image }}
+        {{- if ne $gateway.image "" }}
         sidecar.istio.io/proxyImage: {{ $gateway.image }}
         {{- end }}
 {{ include "toYamlIf" (dict "value" $gateway.podMetadata.annotations) | indent 8 }}

--- a/internal/assets/manifests/istio-meshgateway/templates/deployment.yaml
+++ b/internal/assets/manifests/istio-meshgateway/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         {{- end }}
         sidecar.istio.io/inject: "true"
         inject.istio.io/templates: "{{ .Values.injectionTemplate }}"
+        {{- if contains "/" $gateway.image }}
+        sidecar.istio.io/proxyImage: {{ $gateway.image }}
+        {{- end }}
 {{ include "toYamlIf" (dict "value" $gateway.podMetadata.annotations) | indent 8 }}
     spec:
 {{ include "toYamlIf" (dict "value" $gateway.securityContext "key" "securityContext" "indent" 2) | indent 6 }}

--- a/internal/assets/manifests/istio-meshgateway/values.yaml.tpl
+++ b/internal/assets/manifests/istio-meshgateway/values.yaml.tpl
@@ -32,6 +32,7 @@ deployment:
 {{ toYamlIf (dict "value" .GetVolumes "key" "volumes") | indent 2 }}
 {{ toYamlIf (dict "value" .GetPodDisruptionBudget "key" "podDisruptionBudget") | indent 2 }}
 {{ toYamlIf (dict "value" .GetPodMetadata "key" "podMetadata") | indent 2 }}
+{{ valueIf (dict "value" .GetImage "key" "image") | indent 2 }}
 {{- end }}
 
 {{- with .GetSpec.GetService }}

--- a/internal/components/istiomeshgateway/testdata/imgw-expected-resource-dump.yaml
+++ b/internal/components/istiomeshgateway/testdata/imgw-expected-resource-dump.yaml
@@ -187,6 +187,7 @@ spec:
         podannotation: podannotationvalue
         sidecar.istio.servicemesh.cisco.com/injection-checksum: 08fdba0c89f9bbd6624201d98758746d1bddc78e9004b00259f33b20b7f9efba
         sidecar.istio.servicemesh.cisco.com/meshconfig-checksum: 319ffd3f807ef4516499c6ad68279a1cd07778f5847e65f9aef908eceb1693e3
+        sidecar.istio.io/proxyImage: "container-hub/image-name:tag"
       labels:
         app: demo-gw
         gateway-name: demo-gw

--- a/internal/components/istiomeshgateway/testdata/imgw-expected-values.yaml
+++ b/internal/components/istiomeshgateway/testdata/imgw-expected-values.yaml
@@ -101,6 +101,7 @@ deployment:
       sidecar.istio.servicemesh.cisco.com/meshconfig-checksum: 319ffd3f807ef4516499c6ad68279a1cd07778f5847e65f9aef908eceb1693e3
     labels:
       podlabel: podlabelvalue
+  image: "container-hub/image-name:tag"
 
 service:
   type: LoadBalancer


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #818
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Implements handling of `spec.deployment.image` property to override the proxy image of an `IstioMeshgateway` `Deployment` resource.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
