### PR TITLE
[v2] fix istio leader election env vars

### DIFF
--- a/internal/assets/manifests/istio-discovery/values.yaml.tpl
+++ b/internal/assets/manifests/istio-discovery/values.yaml.tpl
@@ -24,12 +24,8 @@ env:
     value: {{ .WithNamespacedRevision "istio-sidecar-injector" }}
   - name: VALIDATION_WEBHOOK_CONFIG_NAME
     value: {{ .WithNamespacedRevision "istio-validator" }}
-  - name: NAMESPACE_LE_NAME
-    value: {{ .WithRevision "istio-namespace-controller-election" }}
-  - name: VALIDATION_LE_NAME
-    value: {{ .WithRevision "istio-validation-controller-election" }}
-  - name: INGRESS_LE_NAME
-    value: {{ .WithRevision "istio-leader" }}
+  - name: LEADER_ELECTION_NAME_SUFFIX
+    value: {{ .WithRevision "" }}
   - name: CACERT_CONFIG_NAME
     value: {{ .WithRevision "istio-ca-root-cert" }}
   - name: MESHCONFIG_CONFIGMAP_NAME

--- a/internal/components/discovery/testdata/icp-expected-resource-dump.yaml
+++ b/internal/components/discovery/testdata/icp-expected-resource-dump.yaml
@@ -1837,12 +1837,8 @@ spec:
           value: istio-sidecar-injector-cp-v111x-istio-system
         - name: VALIDATION_WEBHOOK_CONFIG_NAME
           value: istio-validator-cp-v111x-istio-system
-        - name: NAMESPACE_LE_NAME
-          value: istio-namespace-controller-election-cp-v111x
-        - name: VALIDATION_LE_NAME
-          value: istio-validation-controller-election-cp-v111x
-        - name: INGRESS_LE_NAME
-          value: istio-leader-cp-v111x
+        - name: LEADER_ELECTION_NAME_SUFFIX
+          value: -cp-v111x
         - name: CACERT_CONFIG_NAME
           value: istio-ca-root-cert-cp-v111x
         - name: MESHCONFIG_CONFIGMAP_NAME

--- a/internal/components/discovery/testdata/icp-expected-values.yaml
+++ b/internal/components/discovery/testdata/icp-expected-values.yaml
@@ -99,12 +99,8 @@ pilot:
       value: istio-sidecar-injector-cp-v111x-istio-system
     - name: VALIDATION_WEBHOOK_CONFIG_NAME
       value: istio-validator-cp-v111x-istio-system
-    - name: NAMESPACE_LE_NAME
-      value: istio-namespace-controller-election-cp-v111x
-    - name: VALIDATION_LE_NAME
-      value: istio-validation-controller-election-cp-v111x
-    - name: INGRESS_LE_NAME
-      value: istio-leader-cp-v111x
+    - name: LEADER_ELECTION_NAME_SUFFIX
+      value: -cp-v111x
     - name: CACERT_CONFIG_NAME
       value: istio-ca-root-cert-cp-v111x
     - name: MESHCONFIG_CONFIGMAP_NAME


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Fixes istiod leader election config map name env variables.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

The env vars to override leader election config map names has changed in Istiod v1.12.
