### PR TITLE
Fix clearing variable issue

### DIFF
--- a/internal/components/components.go
+++ b/internal/components/components.go
@@ -213,7 +213,8 @@ func ConvertConfigStateToReconcileStatus(state v1alpha1.ConfigState) types.Recon
 }
 
 func UpdateStatus(ctx context.Context, c client.Client, object runtime.Object, status types.ReconcileStatus, message string) error {
-	if imgw, ok := object.(ObjectWithStatus); ok {
+	tmpObject := object.DeepCopyObject()
+	if imgw, ok := tmpObject.(ObjectWithStatus); ok {
 		current := &unstructured.Unstructured{}
 		current.SetGroupVersionKind(imgw.GetObjectKind().GroupVersionKind())
 		err := c.Get(context.TODO(), client.ObjectKey{


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

After the `UpdateStatus` function was called the `object` variable was cleared out. This resulted in losing dynamically set values on the object, e.g. the `jwtPolicy` value.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
