### PR TITLE
Move Cluster registry API to new source

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,7 +50,7 @@ linters-settings:
   gocyclo:
     min-complexity: 40
   goimports:
-    local-prefixes: github.com/banzaicloud
+    local-prefixes: github.com/banzaicloud,github.com/cisco-open
   gocritic:
     disabled-checks:
       - ifElseChain

--- a/controllers/istiocontrolplane_controller.go
+++ b/controllers/istiocontrolplane_controller.go
@@ -56,7 +56,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	"sigs.k8s.io/yaml"
 
-	clusterregistryv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
 	servicemeshv1alpha1 "github.com/banzaicloud/istio-operator/api/v2/v1alpha1"
 	"github.com/banzaicloud/istio-operator/v2/internal/components"
 	"github.com/banzaicloud/istio-operator/v2/internal/components/base"
@@ -72,6 +71,7 @@ import (
 	"github.com/banzaicloud/operator-tools/pkg/logger"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	"github.com/banzaicloud/operator-tools/pkg/utils"
+	clusterregistryv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 )
 
 const (

--- a/deploy/charts/istio-operator/README.md
+++ b/deploy/charts/istio-operator/README.md
@@ -58,5 +58,5 @@ Parameter | Description | Default
 `leaderElection.namespace` | Namespace for the leader election configmap | `istio-system`
 `leaderElection.nameOverride` | Name override for the leader election configmap | `""`
 `apiServerEndpointAddress` | Endpoint address of the API server of the cluster the controller is running on | `""`
-`clusterRegistry.clusterAPI.enabled` | If true, [cluster registry](https://github.com/banzaicloud/cluster-registry) API is used from the cluster | `false`
-`clusterRegistry.resourceSyncRules.enabled` | If true, the necessary ResourceSyncRule resources from the [cluster registry](https://github.com/banzaicloud/cluster-registry) API are automatically created for multi cluster setups | `false`
+`clusterRegistry.clusterAPI.enabled` | If true, [cluster registry](https://github.com/cisco-open/cluster-registry-controller/api) API is used from the cluster | `false`
+`clusterRegistry.resourceSyncRules.enabled` | If true, the necessary ResourceSyncRule resources from the [cluster registry](https://github.com/cisco-open/cluster-registry-controller/api) API are automatically created for multi cluster setups | `false`

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	emperror.dev/errors v0.8.0
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
-	github.com/banzaicloud/cluster-registry v0.0.8
 	github.com/banzaicloud/istio-operator/api/v2 v2.0.0
 	github.com/banzaicloud/k8s-objectmatcher v1.8.0
 	github.com/banzaicloud/operator-tools v0.28.2
+	github.com/cisco-open/cluster-registry-controller/api v0.1.9
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/go-logr/logr v1.2.2
 	github.com/gogo/protobuf v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,6 @@ github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZo
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.34.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
-github.com/banzaicloud/cluster-registry v0.0.8 h1:hFVgNDcNeBo2tL1R/iUVx7MEYCqU12TWH3yVE4oRqnk=
-github.com/banzaicloud/cluster-registry v0.0.8/go.mod h1:4ICSf7IMl2mcBByqZ2kZoDwu0bWXGSpHie+6jobSQBI=
 github.com/banzaicloud/k8s-objectmatcher v1.5.0/go.mod h1:9MWY5HsM/OaTmoTirczhlO8UALbH722WgdpaaR7Y8OE=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0 h1:Nugn25elKtPMTA2br+JgHNeSQ04sc05MDPmpJnd1N2A=
 github.com/banzaicloud/k8s-objectmatcher v1.8.0/go.mod h1:p2LSNAjlECf07fbhDyebTkPUIYnU05G+WfGgkTmgeMg=
@@ -239,6 +237,8 @@ github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/cisco-open/cluster-registry-controller/api v0.1.9 h1:dJfvj2umr1fIIOeNDxRR2u1WEpjT0zW+giOczCV/rBY=
+github.com/cisco-open/cluster-registry-controller/api v0.1.9/go.mod h1:+SGsAzdHbD+v+CovGDNqbfEg48p/EiopbLvYZj56Vgg=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/internal/util/predicate.go
+++ b/internal/util/predicate.go
@@ -25,12 +25,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
-	clusterregistryv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
 	servicemeshv1alpha1 "github.com/banzaicloud/istio-operator/api/v2/v1alpha1"
 	pkgUtil "github.com/banzaicloud/istio-operator/v2/pkg/util"
 	"github.com/banzaicloud/k8s-objectmatcher/patch"
 	"github.com/banzaicloud/operator-tools/pkg/logger"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
+	clusterregistryv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 )
 
 type CalculateOption = patch.CalculateOption

--- a/main.go
+++ b/main.go
@@ -30,13 +30,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	// +kubebuilder:scaffold:imports
-	clusterregistryv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
 	servicemeshv1alpha1 "github.com/banzaicloud/istio-operator/api/v2/v1alpha1"
 	"github.com/banzaicloud/istio-operator/v2/controllers"
 	"github.com/banzaicloud/istio-operator/v2/internal/models"
 	"github.com/banzaicloud/istio-operator/v2/pkg/util"
 	"github.com/banzaicloud/operator-tools/pkg/logger"
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
+	clusterregistryv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 )
 
 var (

--- a/pkg/k8sutil/cluster.go
+++ b/pkg/k8sutil/cluster.go
@@ -22,7 +22,7 @@ import (
 	"emperror.dev/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	clusterregistryv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
+	clusterregistryv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 )
 
 func GetLocalCluster(ctx context.Context, kubeClient client.Client) (*clusterregistryv1alpha1.Cluster, error) {

--- a/pkg/k8sutil/cluster_secret.go
+++ b/pkg/k8sutil/cluster_secret.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
-	clusterregistryv1alpha1 "github.com/banzaicloud/cluster-registry/api/v1alpha1"
+	clusterregistryv1alpha1 "github.com/cisco-open/cluster-registry-controller/api/v1alpha1"
 )
 
 func GetExternalAddressOfAPIServer(kubeConfig *rest.Config) (string, error) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | 
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->

Use https://github.com/cisco-open/cluster-registry-controller/tree/master/api instead of https://github.com/banzaicloud/cluster-registry.

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->

API was moved to new repo.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] User guide and development docs updated (if needed)
