### PR TITLE
replace old hpa logic with the original

### DIFF
--- a/internal/assets/manifests/istio-meshgateway/templates/autoscale.yaml
+++ b/internal/assets/manifests/istio-meshgateway/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{ $gateway := .Values.deployment }}
-{{- if and $gateway.replicas.min $gateway.replicas.max (gt ($gateway.replicas.min | int) 0) (gt ($gateway.replicas.max | int) ($gateway.replicas.min | int)) }}
+{{- if and $gateway.autoscaleEnabled $gateway.autoscaleMin $gateway.autoscaleMax }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -8,8 +8,8 @@ metadata:
   labels:
 {{- include "deployment.labels" . | indent 4 }}
 spec:
-  maxReplicas: {{ $gateway.replicas.max }}
-  minReplicas: {{ $gateway.replicas.min }}
+  maxReplicas: {{ $gateway.autoscaleMax }}
+  minReplicas: {{ $gateway.autoscaleMin }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -20,6 +20,6 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ $gateway.replicas.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ $gateway.cpu.targetAverageUtilization }}
 ---
 {{- end }}

--- a/internal/assets/manifests/istio-meshgateway/templates/deployment.yaml
+++ b/internal/assets/manifests/istio-meshgateway/templates/deployment.yaml
@@ -9,7 +9,11 @@ metadata:
 {{- include "deployment.labels" . | indent 4 }}
 {{- include "toYamlIf" (dict "value" $gateway.metadata.annotations "key" "annotations" "indent" 2) | indent 2 }}
 spec:
-  replicas: {{ $gateway.replicas.count | default 1 }}
+{{- if not $gateway.autoscaleEnabled }}
+{{- if $gateway.replicaCount }}
+  replicas: {{ $gateway.replicaCount }}
+{{- end }}
+{{- end }}
   selector:
     matchLabels:
 {{- include "pod.labels" . | indent 6 }}

--- a/internal/assets/manifests/istio-meshgateway/values.yaml
+++ b/internal/assets/manifests/istio-meshgateway/values.yaml
@@ -8,6 +8,7 @@ type: ingress
 runAsRoot: true
 
 deployment:
+  replicaCount: 1
   enablePrometheusMerge: true
   deploymentStrategy:
     type: RollingUpdate
@@ -18,14 +19,11 @@ deployment:
     labels: {}
     annotations: {}
   env: {}
+  cpu:
+    targetAverageUtilization: 80
   affinity: {}
   nodeSelector: {}
   priorityClassName: ""
-  replicas:
-    count: 1
-    min: 1
-    max: 1
-    targetCPUUtilizationPercentage: 80
   resources:
     limits:
       cpu: "2"

--- a/internal/assets/manifests/istio-meshgateway/values.yaml.tpl
+++ b/internal/assets/manifests/istio-meshgateway/values.yaml.tpl
@@ -15,16 +15,30 @@ global:
 {{- end }}
 
 deployment:
-  name: {{ .Name | quote }}
-{{ valueIf (dict "key" "enablePrometheusMerge" "value" .Properties.EnablePrometheusMerge) | indent 2 }}
+{{ valueIf (dict "value" .Name "key" "name") | indent 2 }}
+{{ valueIf (dict "value" .Properties.EnablePrometheusMerge "key" "enablePrometheusMerge") | indent 2 }}
 {{- with .GetSpec.GetDeployment }}
+{{- $replicaCount := .GetReplicas.GetCount.GetValue | int }}
+{{- $autoscaleMin := .GetReplicas.GetMin.GetValue | int }}
+{{- $autoscaleMax := .GetReplicas.GetMax.GetValue | int }}
+{{- $targetCPUUtilization := .GetReplicas.GetTargetCPUUtilizationPercentage.GetValue | int }}
+{{- $autoscaleEnabled := false }}
+{{- if and $autoscaleMin $autoscaleMax }}
+{{- $autoscaleEnabled = and (gt $autoscaleMin 0) (gt $autoscaleMax $autoscaleMin) }}
+{{- end }}
+{{ valueIf (dict "value" $autoscaleEnabled "key" "autoscaleEnabled") | indent 2 }}
+{{ valueIf (dict "value" $autoscaleMin "key" "autoscaleMin") | indent 2 }}
+{{ valueIf (dict "value" $autoscaleMax "key" "autoscaleMax") | indent 2 }}
+{{ valueIf (dict "value" $replicaCount "key" "replicaCount") | indent 2 }}
+{{- if gt $targetCPUUtilization 0 }}
+{{ toYaml (dict "cpu" (dict "targetAverageUtilization" $targetCPUUtilization)) | indent 2 }}
+{{- end }}
 {{ toYamlIf (dict "value" .GetDeploymentStrategy "key" "deploymentStrategy") | indent 2 }}
 {{ toYamlIf (dict "value" .GetMetadata "key" "metadata") | indent 2 }}
 {{ toYamlIf (dict "value" .GetEnv "key" "env") | indent 2 }}
 {{ toYamlIf (dict "value" .GetAffinity "key" "affinity") | indent 2 }}
 {{ toYamlIf (dict "value" .GetNodeSelector "key" "nodeSelector") | indent 2 }}
 {{ valueIf (dict "value" .GetPriorityClassName "key" "priorityClassName") | indent 2 }}
-{{ toYamlIf (dict "value" .GetReplicas "key" "replicas") | indent 2 }}
 {{ toYamlIf (dict "value" .GetResources "key" "resources") | indent 2 }}
 {{ toYamlIf (dict "value" .GetSecurityContext "key" "securityContext") | indent 2 }}
 {{ toYamlIf (dict "value" .GetTolerations "key" "tolerations") | indent 2 }}

--- a/internal/assets/manifests/istio-sidecar-injector/templates/autoscale.yaml
+++ b/internal/assets/manifests/istio-sidecar-injector/templates/autoscale.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.deployment.replicas.min .Values.deployment.replicas.max (gt (.Values.deployment.replicas.min | int) 0) (gt (.Values.deployment.replicas.max | int) (.Values.deployment.replicas.min | int)) }}
+{{- if and .Values.deployment.autoscaleEnabled .Values.deployment.autoscaleMin .Values.deployment.autoscaleMax }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -7,8 +7,8 @@ metadata:
   labels:
 {{- include "generic.labels" . | indent 4 }}
 spec:
-  maxReplicas: {{ .Values.deployment.replicas.max }}
-  minReplicas: {{ .Values.deployment.replicas.min }}
+  maxReplicas: {{ .Values.deployment.autoscaleMax }}
+  minReplicas: {{ .Values.deployment.autoscaleMin }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -19,6 +19,6 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: {{ .Values.deployment.replicas.targetCPUUtilizationPercentage }}
+          averageUtilization: {{ .Values.deployment.cpu.targetAverageUtilization }}
 ---
 {{- end }}

--- a/internal/assets/manifests/istio-sidecar-injector/templates/deployment.yaml
+++ b/internal/assets/manifests/istio-sidecar-injector/templates/deployment.yaml
@@ -7,7 +7,11 @@ metadata:
 {{- include "generic.labels" . | indent 4 }}
 {{- include "toYamlIf" (dict "value" .Values.deployment.metadata.annotations "key" "annotations" "indent" 2) | indent 2 }}
 spec:
-  replicas: {{ .Values.deployment.replicas.count | default 1 }}
+{{- if not .Values.deployment.autoscaleEnabled }}
+{{- if .Values.deployment.replicaCount }}
+  replicas: {{ .Values.deployment.replicaCount }}
+{{- end }}
+{{- end }}
   selector:
     matchLabels:
 {{- include "pod.labels" . | indent 6 }}

--- a/internal/assets/manifests/istio-sidecar-injector/values.yaml
+++ b/internal/assets/manifests/istio-sidecar-injector/values.yaml
@@ -1,6 +1,7 @@
 revision: "default"
 
 deployment:
+  replicaCount: 1
   image: banzaicloud/istio-sidecar-injector:v1.10.4-bzc.1
   enablePrometheusMerge: true
   deploymentStrategy:
@@ -12,13 +13,11 @@ deployment:
     labels: {}
     annotations: {}
   env: {}
+  cpu:
+    targetAverageUtilization: 80
   affinity: {}
   nodeSelector: {}
   priorityClassName: ""
-  replicas:
-    count: 1
-    min: 1
-    max: 1
   resources:
     limits:
       cpu: "250m"

--- a/internal/assets/manifests/istio-sidecar-injector/values.yaml.tpl
+++ b/internal/assets/manifests/istio-sidecar-injector/values.yaml.tpl
@@ -18,7 +18,22 @@ global:
 {{- end }}
 
 {{ define "deployment" }}
-{{ with .GetSpec.GetSidecarInjector.GetDeployment }}
+{{- with .GetSpec.GetSidecarInjector.GetDeployment }}
+{{- $replicaCount := .GetReplicas.GetCount.GetValue | int }}
+{{- $autoscaleMin := .GetReplicas.GetMin.GetValue | int }}
+{{- $autoscaleMax := .GetReplicas.GetMax.GetValue | int }}
+{{- $targetCPUUtilization := .GetReplicas.GetTargetCPUUtilizationPercentage.GetValue | int }}
+{{- $autoscaleEnabled := false }}
+{{- if and $autoscaleMin $autoscaleMax }}
+{{- $autoscaleEnabled = and (gt $autoscaleMin 0) (gt $autoscaleMax $autoscaleMin) }}
+{{- end }}
+{{ valueIf (dict "value" $autoscaleEnabled "key" "autoscaleEnabled") }}
+{{ valueIf (dict "value" $autoscaleMin "key" "autoscaleMin") }}
+{{ valueIf (dict "value" $autoscaleMax "key" "autoscaleMax") }}
+{{ valueIf (dict "value" $replicaCount "key" "replicaCount") }}
+{{- if gt $targetCPUUtilization 0 }}
+{{ toYaml (dict "cpu" (dict "targetAverageUtilization" $targetCPUUtilization)) }}
+{{- end }}
 {{ valueIf (dict "key" "image" "value" .GetImage) }}
 {{ toYamlIf (dict "value" .GetDeploymentStrategy "key" "deploymentStrategy") }}
 {{ toYamlIf (dict "value" .GetMetadata "key" "metadata") }}
@@ -26,18 +41,17 @@ global:
 {{ toYamlIf (dict "value" .GetAffinity "key" "affinity") }}
 {{ toYamlIf (dict "value" .GetNodeSelector "key" "nodeSelector") }}
 {{ valueIf (dict "value" .GetPriorityClassName "key" "priorityClassName") }}
-{{ toYamlIf (dict "value" .GetReplicas "key" "replicas") }}
 {{ toYamlIf (dict "value" .GetResources "key" "resources") }}
 {{ toYamlIf (dict "value" .GetSecurityContext "key" "securityContext") }}
 {{ toYamlIf (dict "value" .GetTolerations "key" "tolerations") }}
-{{ toYamlIf (dict "value" .GetTopologySpreadConstraints "key" "topologySpreadConstraints") | indent 2 }}
+{{ toYamlIf (dict "value" .GetTopologySpreadConstraints "key" "topologySpreadConstraints") }}
 {{ toYamlIf (dict "value" .GetVolumeMounts "key" "volumeMounts") }}
 {{ toYamlIf (dict "value" .GetVolumes "key" "volumes") }}
 {{ toYamlIf (dict "value" .GetPodDisruptionBudget "key" "podDisruptionBudget") }}
 {{ toYamlIf (dict "value" .GetPodMetadata "key" "podMetadata") }}
 {{ toYamlIf (dict "value" .GetLivenessProbe "key" "livenessProbe") }}
 {{ toYamlIf (dict "value" .GetReadinessProbe "key" "readinessProbe") }}
-{{ end }}
+{{- end }}
 {{ end }}
 
 

--- a/internal/components/istiomeshgateway/testdata/imgw-expected-resource-dump.yaml
+++ b/internal/components/istiomeshgateway/testdata/imgw-expected-resource-dump.yaml
@@ -162,7 +162,6 @@ metadata:
   name: demo-gw
   namespace: default
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app: demo-gw

--- a/internal/components/istiomeshgateway/testdata/imgw-expected-values.yaml
+++ b/internal/components/istiomeshgateway/testdata/imgw-expected-values.yaml
@@ -55,10 +55,12 @@ deployment:
   nodeSelector:
     disktype: ssd
   priorityClassName: "high-priority"
-  replicas:
-    count: 1
-    min: 1
-    max: 3
+  autoscaleEnabled: true
+  autoscaleMax: 3
+  autoscaleMin: 1
+  replicaCount: 1
+  cpu:
+    targetAverageUtilization: 80
   resources:
     limits:
       cpu: "2"

--- a/internal/components/istiomeshgateway/testdata/imgw-test-cr.yaml
+++ b/internal/components/istiomeshgateway/testdata/imgw-test-cr.yaml
@@ -81,6 +81,7 @@ spec:
       count: 1
       min: 1
       max: 3
+      targetCPUUtilizationPercentage: 80
     podMetadata:
       annotations:
         podannotation: podannotationvalue

--- a/internal/components/sidecarinjector/testdata/icp-expected-values.yaml
+++ b/internal/components/sidecarinjector/testdata/icp-expected-values.yaml
@@ -20,6 +20,8 @@ deployment:
     value: "true"
   - name: CNI_ANOTHER_ENV_NAME
     value: "standard"
+  cpu:
+    targetAverageUtilization: 80
   nodeSelector:
     disktype: ssd
   affinity:

--- a/internal/components/sidecarinjector/testdata/icp-test-cr.yaml
+++ b/internal/components/sidecarinjector/testdata/icp-test-cr.yaml
@@ -80,6 +80,8 @@ spec:
       volumeMounts:
       - name: config-vol
         mountPath: /etc/config
+      replicas:
+        targetCPUUtilizationPercentage: 80
       readinessProbe:
         handler:
           exec:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | #890
| License         | Apache 2.0

### What's in this PR?
Replace an old autoscaling logic with the default HPA one

### Checklist
- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)

### Tests
* Apply active ICP
* Edit IMGW resource and set min and max for replicas
* Apply passive ICP
* Set sidecarInjector settings in the ICP:
```yaml
spec:
  sidecarInjector:
    deployment:
      replicas:
        max: 4
        min: 1
```
* Make sure that HPA works correctly in the both cases