### PR TITLE
Add istio.io/rev label to istio-cni

### DIFF
--- a/internal/assets/manifests/istio-cni/templates/daemonset.yaml
+++ b/internal/assets/manifests/istio-cni/templates/daemonset.yaml
@@ -23,6 +23,7 @@ spec:
       labels:
         app: istio-cni-node
         release: {{ .Release.Name }}
+        istio.io/rev: {{ include "namespaced-revision" . }}
         sidecar.istio.io/inject: "false"
 {{- include "toYamlIf" (dict "value" .Values.cni.podMetadata.labels) | indent 8 }}
       annotations:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes image pull failure when used with imps-controller
| License         | Apache 2.0

### What's in this PR?
Add `istio.io/rev` label to istio-cni which can match with imps-controller rules to allow pull-secrets to be used by `istio-system` namespace

### Why?
istio-cni image pull failure issue will be resolved in Calisti

### Checklist
- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)