### PR TITLE
Include go mod vendor to resolve licensei detection failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,10 +66,17 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }} # Note: this is required for licensei auth in steps to avoid rate-limiting.
         run: ./bin/licensei list
 
+      - name: Vendor dependencies to retrieve licenses locally
+        # Vendor deps before running https://github.com/goph/licensei
+        # to avoid false-positive when modules github repo could not be determined
+        run: go mod vendor -o vendor
+
       - name: Check dependency licenses
         env:
           GITHUB_TOKEN: ${{ github.token }} # Note: this is required for licensei auth in steps to avoid rate-limiting.
-        run: make license-check
+        run: |
+          make license-check
+          make vendor-clean
 
       - name: Run unit tests, linter, etc.
         run: make check

--- a/.licensei.toml
+++ b/.licensei.toml
@@ -29,7 +29,8 @@ ignored = [
 
 [header]
 ignorePaths = [
-    "build"
+    "build",
+    "vendor"
 ]
 
 ignoreFiles = [

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,10 @@ license-check: bin/licensei ## Run license check
 license-cache: bin/licensei ## Generate license cache
 	bin/licensei cache
 
+.PHONY: vendor-clean
+vendor-clean: ## Clean vendor cache
+	rm -rf ${PWD}/vendor
+
 # Run tests
 .PHONY: test
 test: install-envtest


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes random licensei check failures
| License         | Apache 2.0


### What's in this PR?
Include `go mod vendor` stage in github actions to avoid false-positive when modules github repo could not be determined

### Why?
licensei check fails randomly sometimes when github repo license could not be determined

### Checklist
- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)