### PR TITLE
fixes #919

### DIFF
--- a/internal/assets/manifests/istio-discovery/templates/autoscale.yaml
+++ b/internal/assets/manifests/istio-discovery/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.global.mode "ACTIVE") .Values.pilot.autoscaleEnabled .Values.pilot.autoscaleMin .Values.pilot.autoscaleMax }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "name-with-revision" ( dict "name" "istiod" "context" $) }}

--- a/internal/assets/manifests/istio-discovery/templates/autoscale.yaml
+++ b/internal/assets/manifests/istio-discovery/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{- if and (eq .Values.global.mode "ACTIVE") .Values.pilot.autoscaleEnabled .Values.pilot.autoscaleMin .Values.pilot.autoscaleMax }}
-apiVersion: autoscaling/v2
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "name-with-revision" ( dict "name" "istiod" "context" $) }}

--- a/internal/assets/manifests/istio-meshgateway/templates/autoscale.yaml
+++ b/internal/assets/manifests/istio-meshgateway/templates/autoscale.yaml
@@ -1,6 +1,6 @@
 {{ $gateway := .Values.deployment }}
 {{- if and $gateway.autoscaleEnabled $gateway.autoscaleMin $gateway.autoscaleMax }}
-apiVersion: autoscaling/v2
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $gateway.name }}

--- a/internal/assets/manifests/istio-meshgateway/templates/autoscale.yaml
+++ b/internal/assets/manifests/istio-meshgateway/templates/autoscale.yaml
@@ -1,6 +1,6 @@
 {{ $gateway := .Values.deployment }}
 {{- if and $gateway.autoscaleEnabled $gateway.autoscaleMin $gateway.autoscaleMax }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $gateway.name }}

--- a/internal/assets/manifests/istio-sidecar-injector/templates/autoscale.yaml
+++ b/internal/assets/manifests/istio-sidecar-injector/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.deployment.autoscaleEnabled .Values.deployment.autoscaleMin .Values.deployment.autoscaleMax }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "name-with-revision" ( dict "name" "istio-sidecar-injector" "context" $) }}

--- a/internal/assets/manifests/istio-sidecar-injector/templates/autoscale.yaml
+++ b/internal/assets/manifests/istio-sidecar-injector/templates/autoscale.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.deployment.autoscaleEnabled .Values.deployment.autoscaleMin .Values.deployment.autoscaleMax }}
-apiVersion: autoscaling/v2
+apiVersion: {{ ternary "autoscaling/v2" "autoscaling/v2beta2" (.Capabilities.APIVersions.Has "autoscaling/v2") }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "name-with-revision" ( dict "name" "istio-sidecar-injector" "context" $) }}

--- a/internal/components/discovery/testdata/icp-expected-resource-dump.yaml
+++ b/internal/components/discovery/testdata/icp-expected-resource-dump.yaml
@@ -2178,7 +2178,7 @@ spec:
           optional: true
 
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   labels:

--- a/internal/components/istiomeshgateway/testdata/imgw-expected-resource-dump.yaml
+++ b/internal/components/istiomeshgateway/testdata/imgw-expected-resource-dump.yaml
@@ -294,7 +294,7 @@ spec:
         name: config-vol
 
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: demo-gw


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | yes
| API breaks?     | no
| Deprecations?   | yes
| Related tickets | fixes #919
| License         | Apache 2.0


### What's in this PR?
Changed resource version of HorizontalPodAutoscaler to v2

### Why?
Group deprecation in k8s 1.27

### Additional context
none

### Checklist
- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
