### PR TITLE
cache cluster-registry memory based on rsr namespaces

### DIFF
--- a/internal/assets/manifests/resource-sync-rule/templates/istio-custom-resources-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-custom-resources-sync-rule.yaml
@@ -24,16 +24,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -60,16 +56,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -96,16 +88,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -132,16 +120,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -168,16 +152,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -204,16 +184,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -240,16 +216,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -276,16 +248,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -312,16 +280,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -348,16 +312,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -384,16 +344,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -420,14 +376,10 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
-      namespaces:
-        - {{ .Release.Namespace }}
 {{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-custom-resources-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-custom-resources-sync-rule.yaml
@@ -24,12 +24,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -56,12 +60,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -88,12 +96,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -120,12 +132,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -152,12 +168,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -184,12 +204,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -216,12 +240,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -248,12 +276,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -280,12 +312,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -312,12 +348,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -344,12 +384,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -376,10 +420,14 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - {{ .Release.Namespace }}
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: {{ include "namespaced-revision" . }}
+      namespaces:
+        - {{ .Release.Namespace }}
 {{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/istio-multi-cluster-secret-resource-sync-rule.yaml
@@ -23,6 +23,8 @@ spec:
       content:
       - key: type
         value: k8s.cisco.com/istio-reader-secret
+      namespaces:
+        - {{ .Release.Namespace }}
     mutations:
       labels:
         add:

--- a/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/mesh-resource-sync-rule.yaml
@@ -21,5 +21,7 @@ spec:
     - objectKey:
         name: {{ .Values.meshID }}
         namespace: {{ .Release.Namespace }}
+      namespaces:
+        - {{ .Release.Namespace }}
       syncStatus: true
 {{- end }}

--- a/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
+++ b/internal/assets/manifests/resource-sync-rule/templates/peer-istio-control-plane-resource-sync-rule.yaml
@@ -20,6 +20,8 @@ spec:
     - objectKey:
         name: {{ .Values.revision }}
         namespace: {{ .Release.Namespace }}
+      namespaces:
+        - {{ .Release.Namespace }}
     mutations:
       groupVersionKind:
         kind: PeerIstioControlPlane

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
@@ -209,16 +209,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -246,16 +242,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -283,16 +275,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -320,16 +308,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -388,16 +372,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -460,16 +440,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -497,16 +473,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -534,16 +506,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -571,16 +539,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -608,16 +572,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -645,16 +605,12 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -682,13 +638,9 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
-      namespaces:
-        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
-      namespaces:
-        - istio-system

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-active-resource-dump.yaml
@@ -209,12 +209,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -242,12 +246,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -275,12 +283,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -308,12 +320,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -339,6 +355,8 @@ spec:
           labels:
             - matchLabels:
                 istio.io/rev: cp-v115x.istio-system
+          namespaces:
+            - istio-system
       mutations:
         labels:
           add:
@@ -370,12 +388,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -400,6 +422,8 @@ spec:
         - objectKey:
             name: cp-v115x
             namespace: istio-system
+          namespaces:
+            - istio-system
       mutations:
         groupVersionKind:
           kind: PeerIstioControlPlane
@@ -436,12 +460,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -469,12 +497,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -502,12 +534,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -535,12 +571,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -568,12 +608,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -601,12 +645,16 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system
 
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
@@ -634,9 +682,13 @@ spec:
           operator: DoesNotExist
         - key: istio.io/rev
           operator: DoesNotExist
+      namespaces:
+        - istio-system
     - labels:
       - matchExpressions:
         - key: banzaicloud.io/related-to
           operator: DoesNotExist
         matchLabels:
           istio.io/rev: cp-v115x.istio-system
+      namespaces:
+        - istio-system

--- a/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
+++ b/internal/components/resourcesyncrule/testdata/rsr-expected-passive-resource-dump.yaml
@@ -202,6 +202,8 @@ spec:
             name: mesh1
             namespace: istio-system
           syncStatus: true
+          namespaces:
+            - istio-system
 ---
 apiVersion: clusterregistry.k8s.cisco.com/v1alpha1
 kind: ResourceSyncRule
@@ -225,6 +227,8 @@ spec:
         - objectKey:
             name: cp-v115x
             namespace: istio-system
+          namespaces:
+            - istio-system
       mutations:
         groupVersionKind:
           kind: PeerIstioControlPlane


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes memory issue in multicluster scenario
| License         | Apache 2.0


### What's in this PR?
<!-- Explain the contents of the PR. Give an overview about the implementation, which decisions were made and why. -->
Contains the changes required to limit namespace cache on ResourceSyncRule `rules.match.namespaces`
This PR adds the namespaces field to chart release namespace in ResourceSyncRule.

With changes in cluster-registry-controller here https://github.com/cisco-open/cluster-registry-controller/pull/62
Limit caching on requiredNamespaces can be used in `spec.rules.match.namespaces`

### Why?
<!-- Which problem does the PR fix? (Please remove this section if you linked an issue above) -->
In a large cluster with many namespaces, cluster-registry can consume memory resources and reach OOMKilled state due to memory limitations. This change adds namespaces filed to RSR rule to cache on istio-operator release namespace to reduce memory consumption.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] Implementation tested
- [x] Error handling code meets the [guideline](https://github.com/banzaicloud/pipeline/blob/master/docs/error-handling-guide.md)
- [x] Logging code meets the guideline
- [x] User guide and development docs updated (if needed)
